### PR TITLE
[#11] 사용자의 언어레벨을 변경할 수 있는 기능구현

### DIFF
--- a/src/main/java/me/soo/helloworld/controller/LanguageController.java
+++ b/src/main/java/me/soo/helloworld/controller/LanguageController.java
@@ -18,4 +18,10 @@ public class LanguageController {
 
         languageService.addLanguages(userId, languageDataWrapper.getDataList(), languageDataWrapper.getStatus());
     }
+
+    @PutMapping
+    public void modifyLanguageLevel(@CurrentUser String userId, @RequestBody LanguageDataWrapper languageDataWrapper) {
+
+        languageService.modifyLevel(userId, languageDataWrapper.getDataList(), languageDataWrapper.getStatus());
+    }
 }

--- a/src/main/java/me/soo/helloworld/controller/LanguageController.java
+++ b/src/main/java/me/soo/helloworld/controller/LanguageController.java
@@ -2,7 +2,7 @@ package me.soo.helloworld.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.soo.helloworld.annotation.CurrentUser;
-import me.soo.helloworld.model.language.LanguageDataWrapper;
+import me.soo.helloworld.model.language.LanguageUpsertRequest;
 import me.soo.helloworld.service.LanguageService;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,14 +14,14 @@ public class LanguageController {
     private final LanguageService languageService;
 
     @PostMapping
-    public void addLanguages(@CurrentUser String userId, @RequestBody LanguageDataWrapper languageDataWrapper) {
+    public void addLanguages(@CurrentUser String userId, @RequestBody LanguageUpsertRequest languageAddRequest) {
 
-        languageService.addLanguages(userId, languageDataWrapper.getDataList(), languageDataWrapper.getStatus());
+        languageService.addLanguages(userId, languageAddRequest.getLanguagesRequest(), languageAddRequest.getStatus());
     }
 
     @PutMapping
-    public void modifyLanguageLevel(@CurrentUser String userId, @RequestBody LanguageDataWrapper languageDataWrapper) {
+    public void modifyLanguageLevel(@CurrentUser String userId, @RequestBody LanguageUpsertRequest languageModifyRequest) {
 
-        languageService.modifyLevel(userId, languageDataWrapper.getDataList(), languageDataWrapper.getStatus());
+        languageService.modifyLevel(userId, languageModifyRequest.getLanguagesRequest(), languageModifyRequest.getStatus());
     }
 }

--- a/src/main/java/me/soo/helloworld/mapper/LanguageMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/LanguageMapper.java
@@ -18,4 +18,7 @@ public interface LanguageMapper {
 
     public List<LanguageData> getLanguages(String userId);
 
+    public void updateLevel(@Param("userId") String userId,
+                            @Param("langNewLevel") List<LanguageData> langNewLevel,
+                            LanguageStatus status);
 }

--- a/src/main/java/me/soo/helloworld/mapper/LanguageMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/LanguageMapper.java
@@ -18,7 +18,7 @@ public interface LanguageMapper {
 
     public List<LanguageData> getLanguages(String userId);
 
-    public void updateLevel(@Param("userId") String userId,
-                            @Param("langNewLevel") List<LanguageData> langNewLevel,
+    public void updateLevels(@Param("userId") String userId,
+                            @Param("languageNewLevels") List<LanguageData> languageNewLevels,
                             LanguageStatus status);
 }

--- a/src/main/java/me/soo/helloworld/model/language/LanguageUpsertRequest.java
+++ b/src/main/java/me/soo/helloworld/model/language/LanguageUpsertRequest.java
@@ -8,9 +8,9 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class LanguageDataWrapper {
+public class LanguageUpsertRequest {
 
-    private final List<LanguageData> dataList;
+    private final List<LanguageData> languagesRequest;
 
     private final LanguageStatus status;
 }

--- a/src/main/java/me/soo/helloworld/service/LanguageService.java
+++ b/src/main/java/me/soo/helloworld/service/LanguageService.java
@@ -9,7 +9,6 @@ import me.soo.helloworld.exception.LanguageLimitExceededException;
 import me.soo.helloworld.mapper.LanguageMapper;
 import me.soo.helloworld.model.language.LanguageData;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,33 +36,32 @@ public class LanguageService {
             1) 추가할 언어의 status 는 NATIVE 인데, level 이 NATIVE 로 지정되어 있지 않은 경우
             2) 추가할 언어의 status 는 NATIVE 가 아닌데, level 이 NATIVE 로 지정되어 있는 경우
      */
-    public void addLanguages(String userId, List<LanguageData> newLangData, LanguageStatus status) {
+    public void addLanguages(String userId, List<LanguageData> newLanguages, LanguageStatus status) {
         int dbLangCounts = languageMapper.countLanguages(userId, status);
 
-        if (dbLangCounts + newLangData.size() > status.getAddLimit()) {
+        if (dbLangCounts + newLanguages.size() > status.getAddLimit()) {
             throw new LanguageLimitExceededException("해당 status 로 추가 가능한 언어의 개수를 초과하였습니다.");
         }
 
-        validateLevel(newLangData, status);
+        validateLevel(newLanguages, status);
 
-        List<LanguageData> existingLangData = getLanguages(userId);
-        checkDuplicateLanguage(existingLangData, newLangData);
+        List<LanguageData> existingLanguages = getLanguages(userId);
+        checkDuplicateLanguage(existingLanguages, newLanguages);
 
-        languageMapper.insertLanguages(userId, newLangData, status);
+        languageMapper.insertLanguages(userId, newLanguages, status);
     }
 
     public List<LanguageData> getLanguages(String userId) {
         return languageMapper.getLanguages(userId);
     }
 
-    @Transactional
-    public void modifyLevel(String userId, List<LanguageData> langNewLevel, LanguageStatus status) {
+    public void modifyLevel(String userId, List<LanguageData> languageNewLevels, LanguageStatus status) {
         if (status.equals(LanguageStatus.NATIVE)) {
             throw new InvalidLanguageLevelException("언어 status 가 모국어(NATIVE)로 등록되어 있는 언어들은 레벨을 변경할 수 없습니다.");
         }
 
-        validateLevel(langNewLevel, status);
-        languageMapper.updateLevel(userId, langNewLevel, status);
+        validateLevel(languageNewLevels, status);
+        languageMapper.updateLevels(userId, languageNewLevels, status);
     }
 
     /*
@@ -72,15 +70,15 @@ public class LanguageService {
         1. 새로 요청받은 언어 목록 중에 중복되는 언어가 있는 경우 예외 발생
         2. DB 내에 추가된 언어 목록과 비교해서 중복 요청이 들어온 경우 예외 발생
      */
-    private void checkDuplicateLanguage(List<LanguageData> existingLangData, List<LanguageData> newLangData) {
-        List<Integer> newLangIds = extractLanguageIdsOnly(newLangData);
+    private void checkDuplicateLanguage(List<LanguageData> existingLanguages, List<LanguageData> newLanguages) {
+        List<Integer> newLangIds = extractLanguageIdsOnly(newLanguages);
 
         // 새로 요청 받은 언어목록을 확인
         if (newLangIds.size() != newLangIds.stream().distinct().count()) {
             throw new DuplicateLanguageException("새로 요청 받은 언어들 중에 중복되는 언어가 존재합니다. 중복 선택은 불가능 합니다.");
         }
 
-        List<Integer> existingLangIds = extractLanguageIdsOnly(existingLangData);
+        List<Integer> existingLangIds = extractLanguageIdsOnly(existingLanguages);
 
         // 기존 언어목록과 새로 요청받은 언어목록을 비교
         if (newLangIds.stream().anyMatch(existingLangIds::contains)) {
@@ -88,9 +86,9 @@ public class LanguageService {
         }
     }
 
-    private List<Integer> extractLanguageIdsOnly(List<LanguageData> langList) {
-        return langList.stream()
-                .map(langId -> langList.get(langList.indexOf(langId)).getId())
+    private List<Integer> extractLanguageIdsOnly(List<LanguageData> languages) {
+        return languages.stream()
+                .map(langId -> languages.get(languages.indexOf(langId)).getId())
                 .collect(Collectors.toList());
     }
 
@@ -103,19 +101,19 @@ public class LanguageService {
         2. Status 가 Native 가 아닌 경우 (CAN_SPEAK or LEARNING)
         - 어떤 언어도 레벨이 NATIVE 가 되어서는 안됩니다.
      */
-    private void validateLevel(List<LanguageData> newLangData, LanguageStatus status) {
+    private void validateLevel(List<LanguageData> languages, LanguageStatus status) {
         boolean isLevelValid;
 
         switch (status) {
             case NATIVE:
-                isLevelValid = newLangData.stream()
-                                            .allMatch(level -> newLangData.get(newLangData.indexOf(level))
+                isLevelValid = languages.stream()
+                                            .allMatch(level -> languages.get(languages.indexOf(level))
                                             .getLevel().equals(LanguageLevel.NATIVE));
                 break;
             case CAN_SPEAK:
             case LEARNING:
-                isLevelValid = newLangData.stream()
-                                        .noneMatch(level -> newLangData.get(newLangData.indexOf(level))
+                isLevelValid = languages.stream()
+                                        .noneMatch(level -> languages.get(languages.indexOf(level))
                                         .getLevel().equals(LanguageLevel.NATIVE));
                 break;
             default:

--- a/src/main/java/me/soo/helloworld/service/LanguageService.java
+++ b/src/main/java/me/soo/helloworld/service/LanguageService.java
@@ -9,6 +9,7 @@ import me.soo.helloworld.exception.LanguageLimitExceededException;
 import me.soo.helloworld.mapper.LanguageMapper;
 import me.soo.helloworld.model.language.LanguageData;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -53,6 +54,16 @@ public class LanguageService {
 
     public List<LanguageData> getLanguages(String userId) {
         return languageMapper.getLanguages(userId);
+    }
+
+    @Transactional
+    public void modifyLevel(String userId, List<LanguageData> langNewLevel, LanguageStatus status) {
+        if (status.equals(LanguageStatus.NATIVE)) {
+            throw new InvalidLanguageLevelException("언어 status 가 모국어(NATIVE)로 등록되어 있는 언어들은 레벨을 변경할 수 없습니다.");
+        }
+
+        validateLevel(langNewLevel, status);
+        languageMapper.updateLevel(userId, langNewLevel, status);
     }
 
     /*
@@ -113,8 +124,8 @@ public class LanguageService {
         }
 
         if (!isLevelValid) {
-            throw new InvalidLanguageLevelException("추가하실 언어에 대한 레벨을 잘못 입력하셨습니다. 모국어 추가는 NATIVE 레벨로만 설정이 가능하며," +
-                    " 모국어가 아닌 언어를 추가시에는 NATIVE 레벨로 설정이 불가능합니다.");
+            throw new InvalidLanguageLevelException("추가하실 언어에 대한 레벨을 잘못 입력하셨습니다. 모국어의 언어 레벨은 NATIVE 레벨로만 설정이 가능하며," +
+                    " 모국어가 아닌 언어에는 NATIVE 레벨로 설정이 불가능합니다.");
         }
     }
 

--- a/src/main/java/me/soo/helloworld/util/handler/ControllerExceptionHandler.java
+++ b/src/main/java/me/soo/helloworld/util/handler/ControllerExceptionHandler.java
@@ -52,7 +52,7 @@ public class ControllerExceptionHandler {
     })
     public ResponseEntity<ExceptionResponse> checkLanguageException(final RuntimeException ex) {
         log.error(ex.getMessage(), ex);
-        ExceptionResponse response = new ExceptionResponse("언어 정보 추가에 실패하였습니다.", ex.getMessage());
+        ExceptionResponse response = new ExceptionResponse("언어 정보 추가/변경에 실패하였습니다.", ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 # DB 커넥션을 위한 DB 정보 저장(코드의 중복/실수 방지)
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/helloworld
+spring.datasource.url=jdbc:mysql://localhost:3306/helloworld?allowMultiQueries=true
 spring.datasource.username=helloworld
 spring.datasource.password=helloworld
 

--- a/src/main/resources/mappers/LanguageMapper.xml
+++ b/src/main/resources/mappers/LanguageMapper.xml
@@ -27,4 +27,13 @@
         SELECT langId, level FROM speak
             WHERE userId = #{userId}
     </select>
+
+    <update id="updateLevel" parameterType="map">
+        <foreach collection="langNewLevel" item="lang" separator=";">
+
+            UPDATE speak
+                SET level = #{lang.level}
+                WHERE langId = #{lang.id} AND status = #{status}
+        </foreach>
+    </update>
 </mapper>

--- a/src/main/resources/mappers/LanguageMapper.xml
+++ b/src/main/resources/mappers/LanguageMapper.xml
@@ -28,12 +28,17 @@
             WHERE userId = #{userId}
     </select>
 
-    <update id="updateLevel" parameterType="map">
-        <foreach collection="langNewLevel" item="lang" separator=";">
-
-            UPDATE speak
-                SET level = #{lang.level}
-                WHERE langId = #{lang.id} AND status = #{status}
-        </foreach>
+    <update id="updateLevels" parameterType="map">
+            UPDATE speak SET level =
+            CASE
+                <foreach collection="languageNewLevels" item="lang">
+                    WHEN langId = #{lang.id} THEN #{lang.level}
+                </foreach>
+            END
+                WHERE langId IN
+                    <foreach collection="languageNewLevels" item="lang" open="(" close=")" separator=",">
+                        #{lang.id}
+                    </foreach>
+                AND userId = #{userId} AND status = #{status}
     </update>
 </mapper>

--- a/src/test/java/me/soo/helloworld/service/language/AddLanguageTestIntegration.java
+++ b/src/test/java/me/soo/helloworld/service/language/AddLanguageTestIntegration.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @Transactional
-public class LanguageServiceIntegrationTest {
+public class AddLanguageTestIntegration {
     private final String userId = "Soo1045";
 
     @Autowired

--- a/src/test/java/me/soo/helloworld/service/language/ModifyLevelTestIntegration.java
+++ b/src/test/java/me/soo/helloworld/service/language/ModifyLevelTestIntegration.java
@@ -1,0 +1,140 @@
+package me.soo.helloworld.service.language;
+
+import lombok.extern.slf4j.Slf4j;
+import me.soo.helloworld.enumeration.LanguageLevel;
+import me.soo.helloworld.enumeration.LanguageStatus;
+import me.soo.helloworld.exception.InvalidLanguageLevelException;
+import me.soo.helloworld.model.language.LanguageData;
+import me.soo.helloworld.service.LanguageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static me.soo.helloworld.service.language.TestLangId.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Slf4j
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Transactional
+public class ModifyLevelTestIntegration {
+
+    private final String userId = "Soo1045";
+
+    @Autowired
+    LanguageService languageService;
+
+    List<LanguageData> learningLang;
+
+    List<LanguageData> canSpeakLang;
+
+    List<LanguageData> nativeLang;
+
+    List<LanguageData> learningLangValidLevelSet;
+
+    List<LanguageData> canSpeakLangValidLevelSet;
+
+    List<LanguageData> learningLangInvalidLevelSet;
+
+    List<LanguageData> canSpeakLangInValidLevelSet;
+
+
+    @BeforeEach
+    public void setUp() {
+        learningLang = new ArrayList<>();
+        learningLang.add(new LanguageData(KOREAN, LanguageLevel.BEGINNER));
+        learningLang.add(new LanguageData(ENGLISH, LanguageLevel.BEGINNER));
+        learningLang.add(new LanguageData(FRENCH, LanguageLevel.BEGINNER));
+        learningLang.add(new LanguageData(SPANISH, LanguageLevel.BEGINNER));
+
+        canSpeakLang = new ArrayList<>();
+        canSpeakLang.add(new LanguageData(RUSSIAN, LanguageLevel.BEGINNER));
+        canSpeakLang.add(new LanguageData(GERMAN, LanguageLevel.BEGINNER));
+        canSpeakLang.add(new LanguageData(ITALIAN, LanguageLevel.BEGINNER));
+        canSpeakLang.add(new LanguageData(CHINESE_CANTONESE, LanguageLevel.BEGINNER));
+
+        nativeLang = new ArrayList<>();
+        nativeLang.add(new LanguageData(RUSSIAN, LanguageLevel.NATIVE));
+        nativeLang.add(new LanguageData(GERMAN, LanguageLevel.NATIVE));
+        nativeLang.add(new LanguageData(ITALIAN, LanguageLevel.NATIVE));
+        nativeLang.add(new LanguageData(CHINESE_CANTONESE, LanguageLevel.NATIVE));
+
+        learningLangValidLevelSet = new ArrayList<>();
+        learningLangValidLevelSet.add(new LanguageData(KOREAN, LanguageLevel.ADVANCED));
+        learningLangValidLevelSet.add(new LanguageData(ENGLISH, LanguageLevel.PROFICIENCY));
+        learningLangValidLevelSet.add(new LanguageData(FRENCH, LanguageLevel.UPPER_INTERMEDIATE));
+        learningLangValidLevelSet.add(new LanguageData(SPANISH, LanguageLevel.ELEMENTARY));
+
+        canSpeakLangValidLevelSet = new ArrayList<>();
+        canSpeakLangValidLevelSet.add(new LanguageData(RUSSIAN, LanguageLevel.ADVANCED));
+        canSpeakLangValidLevelSet.add(new LanguageData(GERMAN, LanguageLevel.PROFICIENCY));
+        canSpeakLangValidLevelSet.add(new LanguageData(ITALIAN, LanguageLevel.UPPER_INTERMEDIATE));
+        canSpeakLangValidLevelSet.add(new LanguageData(CHINESE_CANTONESE, LanguageLevel.ELEMENTARY));
+
+        learningLangInvalidLevelSet = new ArrayList<>();
+        learningLangInvalidLevelSet.add(new LanguageData(KOREAN, LanguageLevel.ADVANCED));
+        learningLangInvalidLevelSet.add(new LanguageData(ENGLISH, LanguageLevel.PROFICIENCY));
+        learningLangInvalidLevelSet.add(new LanguageData(FRENCH, LanguageLevel.UPPER_INTERMEDIATE));
+        learningLangInvalidLevelSet.add(new LanguageData(SPANISH, LanguageLevel.NATIVE));
+
+        canSpeakLangInValidLevelSet = new ArrayList<>();
+        canSpeakLangInValidLevelSet.add(new LanguageData(RUSSIAN, LanguageLevel.ADVANCED));
+        canSpeakLangInValidLevelSet.add(new LanguageData(GERMAN, LanguageLevel.PROFICIENCY));
+        canSpeakLangInValidLevelSet.add(new LanguageData(ITALIAN, LanguageLevel.UPPER_INTERMEDIATE));
+        canSpeakLangInValidLevelSet.add(new LanguageData(CHINESE_CANTONESE, LanguageLevel.NATIVE));
+    }
+
+    @Test
+    @DisplayName("추가된 언어 Status 가 Native 가 아닌 언어들에 대한 언어 레벨 변경이 이루어질 경우 테스트에 성공합니다.")
+    public void learningLangModifyLevelSuccess() {
+        languageService.addLanguages(userId, learningLang, LanguageStatus.LEARNING);
+        languageService.addLanguages(userId, canSpeakLang, LanguageStatus.CAN_SPEAK);
+
+        languageService.modifyLevel(userId, learningLangValidLevelSet, LanguageStatus.LEARNING);
+        languageService.modifyLevel(userId, canSpeakLangValidLevelSet, LanguageStatus.CAN_SPEAK);
+
+        List<LanguageData> languageList = languageService.getLanguages(userId);
+
+        Map<Integer, LanguageLevel> languageMap = languageList.stream()
+                .collect(Collectors.toMap(LanguageData::getId, LanguageData::getLevel));
+
+        assertTrue(learningLangValidLevelSet.stream().allMatch(languageData -> languageMap.get(languageData.getId()).equals(languageData.getLevel())));
+        assertTrue(canSpeakLangValidLevelSet.stream().allMatch(languageData -> languageMap.get(languageData.getId()).equals(languageData.getLevel())));
+    }
+
+    @Test
+    @DisplayName("언어레벨 변경 요청으로 들어온 레벨 값들 중 모국어(NATIVE) LEVEL 이 들어있으면 InvalidLanguageLevelException 이 발생하며 테스트에 실패합니다.")
+    public void learningLangModifyLevelFailWithNativeLangStatus() {
+        languageService.addLanguages(userId, learningLang, LanguageStatus.LEARNING);
+        languageService.addLanguages(userId, canSpeakLang, LanguageStatus.CAN_SPEAK);
+
+        assertThrows(InvalidLanguageLevelException.class, () -> {
+            languageService.modifyLevel(userId, learningLangInvalidLevelSet, LanguageStatus.LEARNING);
+        });
+
+        assertThrows(InvalidLanguageLevelException.class, () -> {
+            languageService.modifyLevel(userId, canSpeakLangInValidLevelSet, LanguageStatus.CAN_SPEAK);
+        });
+    }
+
+    @Test
+    @DisplayName("언어 Status 가 모국어(Native) 로 등록된 언어에 대해 레벨 변경 요청이 들어오면 InvalidLanguageLevelException 이 발생하며 테스트에 실패합니다.")
+    public void canSpeakLangModifyLevelSuccess() {
+        languageService.addLanguages(userId, nativeLang, LanguageStatus.NATIVE);
+
+        assertThrows(InvalidLanguageLevelException.class, () -> {
+            languageService.modifyLevel(userId, nativeLang, LanguageStatus.NATIVE);
+        });
+    }
+}


### PR DESCRIPTION
## Controller 계층 관련

### LanguageController (new)

- 사용자가 등록한 언어 레벨 변경 요청을 받을 `modifyLanguageLevel` 메소드 추가

## Service 계층 관련

### LanguageService (new)

- 언어 레벨 변경 요청에 대한 로직을 처리할 `modifyLevel` 메소드 추가

1. 등록된 언어 status 가 `모국어(NATIVE)` 인 언어들의 경우에는 레벨
   변경이 불가능 (예외)

2. 필요시 여러 개의 언어레벨 변경 요청을 한번에 받아 처리해야
   `@Transactional` annotation 추가

## Mapper 계층 관련

### LanguageMapper

- 서비스 계층에서 처리한 언어레벨 변경에 대한 요청을 DB에 반영하기 위한
  `updateLevel` 메소드 작성

### LangaugeMapper.xml

- 위의 메소드를 처리하기 위한 Query 추가

## application.properties

- Mybatis가 한 번에 여러 요청을 처리할 수 있도록 `allowMultipleQueries` 속성값 true
  추가

## 테스트 관련

- 위에서 작성한 로직을 통합 테스트 할 클래스 추가

- 포스트맨을 활용해 구현한 로직 테스트