### PR TITLE
[#12] 사용자가 등록한 언어 삭제 기능 구현

### DIFF
--- a/src/main/java/me/soo/helloworld/controller/LanguageController.java
+++ b/src/main/java/me/soo/helloworld/controller/LanguageController.java
@@ -16,13 +16,15 @@ public class LanguageController {
     private final LanguageService languageService;
 
     @PostMapping("/languages")
-    public void addLanguages(@CurrentUser String userId, @RequestBody LanguageUpsertRequest languageAddRequest) {
+    public void addLanguages(@CurrentUser String userId,
+                             @RequestBody LanguageUpsertRequest languageAddRequest) {
 
         languageService.addLanguages(userId, languageAddRequest.getLanguagesRequest(), languageAddRequest.getStatus());
     }
 
     @PutMapping("/languages")
-    public void modifyLanguageLevels(@CurrentUser String userId, @RequestBody LanguageUpsertRequest languageModifyRequest) {
+    public void modifyLanguageLevels(@CurrentUser String userId,
+                                     @RequestBody LanguageUpsertRequest languageModifyRequest) {
 
         languageService.modifyLanguageLevels(userId, languageModifyRequest.getLanguagesRequest(), languageModifyRequest.getStatus());
     }

--- a/src/main/java/me/soo/helloworld/controller/LanguageController.java
+++ b/src/main/java/me/soo/helloworld/controller/LanguageController.java
@@ -9,25 +9,25 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/languages")
+@RequestMapping("/my-infos")
 @RequiredArgsConstructor
 public class LanguageController {
 
     private final LanguageService languageService;
 
-    @PostMapping
+    @PostMapping("/languages")
     public void addLanguages(@CurrentUser String userId, @RequestBody LanguageUpsertRequest languageAddRequest) {
 
         languageService.addLanguages(userId, languageAddRequest.getLanguagesRequest(), languageAddRequest.getStatus());
     }
 
-    @PutMapping
-    public void modifyLanguageLevel(@CurrentUser String userId, @RequestBody LanguageUpsertRequest languageModifyRequest) {
+    @PutMapping("/languages")
+    public void modifyLanguageLevels(@CurrentUser String userId, @RequestBody LanguageUpsertRequest languageModifyRequest) {
 
-        languageService.modifyLevel(userId, languageModifyRequest.getLanguagesRequest(), languageModifyRequest.getStatus());
+        languageService.modifyLanguageLevels(userId, languageModifyRequest.getLanguagesRequest(), languageModifyRequest.getStatus());
     }
 
-    @DeleteMapping
+    @DeleteMapping("/languages")
     public void deleteLanguages(@CurrentUser String userId,
                                 @RequestBody List<Integer> languageDeleteRequest) {
 

--- a/src/main/java/me/soo/helloworld/controller/LanguageController.java
+++ b/src/main/java/me/soo/helloworld/controller/LanguageController.java
@@ -6,6 +6,8 @@ import me.soo.helloworld.model.language.LanguageDataWrapper;
 import me.soo.helloworld.service.LanguageService;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/languages")
 @RequiredArgsConstructor
@@ -23,5 +25,12 @@ public class LanguageController {
     public void modifyLanguageLevel(@CurrentUser String userId, @RequestBody LanguageDataWrapper languageDataWrapper) {
 
         languageService.modifyLevel(userId, languageDataWrapper.getDataList(), languageDataWrapper.getStatus());
+    }
+
+    @DeleteMapping
+    public void deleteLanguages(@CurrentUser String userId,
+                                @RequestBody List<Integer> languageDeleteRequest) {
+
+        languageService.deleteLanguages(userId, languageDeleteRequest);
     }
 }

--- a/src/main/java/me/soo/helloworld/mapper/LanguageMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/LanguageMapper.java
@@ -21,4 +21,7 @@ public interface LanguageMapper {
     public void updateLevel(@Param("userId") String userId,
                             @Param("langNewLevel") List<LanguageData> langNewLevel,
                             LanguageStatus status);
+
+    public void deleteLanguages(@Param("userId") String userId,
+                                @Param("languages") List<Integer> languages);
 }

--- a/src/main/java/me/soo/helloworld/service/LanguageService.java
+++ b/src/main/java/me/soo/helloworld/service/LanguageService.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class LanguageService {
+    private static final int MAX_TOTAL_LANGUAGES = 16;
 
     private final LanguageMapper languageMapper;
 
@@ -64,6 +65,14 @@ public class LanguageService {
 
         validateLevel(langNewLevel, status);
         languageMapper.updateLevel(userId, langNewLevel, status);
+    }
+
+    public void deleteLanguages(String userId, List<Integer> languages) {
+        if (languages.size() > MAX_TOTAL_LANGUAGES) {
+            throw new LanguageLimitExceededException("삭제하려는 언어의 개수는 등록 가능한 언어의 최대 개수를 넘을 수 없습니다.");
+        }
+
+        languageMapper.deleteLanguages(userId, languages);
     }
 
     /*

--- a/src/main/java/me/soo/helloworld/service/LanguageService.java
+++ b/src/main/java/me/soo/helloworld/service/LanguageService.java
@@ -56,7 +56,7 @@ public class LanguageService {
         return languageMapper.getLanguages(userId);
     }
 
-    public void modifyLevel(String userId, List<LanguageData> languageNewLevels, LanguageStatus status) {
+    public void modifyLanguageLevels(String userId, List<LanguageData> languageNewLevels, LanguageStatus status) {
         if (status.equals(LanguageStatus.NATIVE)) {
             throw new InvalidLanguageLevelException("언어 status 가 모국어(NATIVE)로 등록되어 있는 언어들은 레벨을 변경할 수 없습니다.");
         }

--- a/src/main/java/me/soo/helloworld/util/handler/ControllerExceptionHandler.java
+++ b/src/main/java/me/soo/helloworld/util/handler/ControllerExceptionHandler.java
@@ -52,7 +52,7 @@ public class ControllerExceptionHandler {
     })
     public ResponseEntity<ExceptionResponse> checkLanguageException(final RuntimeException ex) {
         log.error(ex.getMessage(), ex);
-        ExceptionResponse response = new ExceptionResponse("언어 정보 추가/변경에 실패하였습니다.", ex.getMessage());
+        ExceptionResponse response = new ExceptionResponse("언어 정보 추가/변경/삭제에 실패하였습니다.", ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/resources/mappers/LanguageMapper.xml
+++ b/src/main/resources/mappers/LanguageMapper.xml
@@ -36,4 +36,13 @@
                 WHERE langId = #{lang.id} AND status = #{status}
         </foreach>
     </update>
+
+    <delete id="deleteLanguages" parameterType="map">
+
+        DELETE FROM speak WHERE langId IN
+            <foreach collection="languages" item="lang" open="(" close=")" separator=",">
+                #{lang}
+            </foreach>
+            AND userId = #{userId}
+    </delete>
 </mapper>

--- a/src/test/java/me/soo/helloworld/service/language/DeleteLanguageIntegrationTest.java
+++ b/src/test/java/me/soo/helloworld/service/language/DeleteLanguageIntegrationTest.java
@@ -1,0 +1,164 @@
+package me.soo.helloworld.service.language;
+
+import lombok.extern.slf4j.Slf4j;
+import me.soo.helloworld.enumeration.LanguageLevel;
+import me.soo.helloworld.enumeration.LanguageStatus;
+import me.soo.helloworld.exception.LanguageLimitExceededException;
+import me.soo.helloworld.model.language.LanguageData;
+import me.soo.helloworld.service.LanguageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static me.soo.helloworld.service.language.TestLangId.*;
+import static me.soo.helloworld.service.language.TestLangId.CHINESE_CANTONESE;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Transactional
+public class DeleteLanguageIntegrationTest {
+
+    private final String user = "Soo1045";
+
+    List<LanguageData> newLearningLangRequest;
+
+    List<LanguageData> newCanSpeakLangRequest;
+
+    List<LanguageData> newNativeLangRequest;
+
+    List<Integer> langInDB;
+
+    List<Integer> overLimitLang;
+
+    @Autowired
+    LanguageService languageService;
+
+    @BeforeEach
+    public void createNewLangRequests() {
+        newLearningLangRequest = new ArrayList<>();
+        newLearningLangRequest.add(new LanguageData(KOREAN, LanguageLevel.BEGINNER));
+        newLearningLangRequest.add(new LanguageData(ENGLISH, LanguageLevel.BEGINNER));
+        newLearningLangRequest.add(new LanguageData(FRENCH, LanguageLevel.BEGINNER));
+        newLearningLangRequest.add(new LanguageData(SPANISH, LanguageLevel.BEGINNER));
+
+        newCanSpeakLangRequest = new ArrayList<>();
+        newCanSpeakLangRequest.add(new LanguageData(RUSSIAN, LanguageLevel.BEGINNER));
+        newCanSpeakLangRequest.add(new LanguageData(GERMAN, LanguageLevel.BEGINNER));
+        newCanSpeakLangRequest.add(new LanguageData(ITALIAN, LanguageLevel.BEGINNER));
+        newCanSpeakLangRequest.add(new LanguageData(CHINESE_CANTONESE, LanguageLevel.BEGINNER));
+
+        newNativeLangRequest = new ArrayList<>();
+        newNativeLangRequest.add(new LanguageData(CHINESE_MANDARIN, LanguageLevel.NATIVE));
+        newNativeLangRequest.add(new LanguageData(ARABIC, LanguageLevel.NATIVE));
+        newNativeLangRequest.add(new LanguageData(DUTCH, LanguageLevel.NATIVE));
+        newNativeLangRequest.add(new LanguageData(PORTUGUESE, LanguageLevel.NATIVE));
+    }
+
+    @BeforeEach
+    public void createUserLangList() {
+        langInDB = new ArrayList<>();
+        langInDB.add(KOREAN);
+        langInDB.add(ENGLISH);
+        langInDB.add(FRENCH);
+        langInDB.add(SPANISH);
+        langInDB.add(RUSSIAN);
+        langInDB.add(GERMAN);
+        langInDB.add(ITALIAN);
+        langInDB.add(CHINESE_CANTONESE);
+        langInDB.add(CHINESE_MANDARIN);
+        langInDB.add(ARABIC);
+        langInDB.add(DUTCH);
+        langInDB.add(PORTUGUESE);
+    }
+
+    @BeforeEach
+    public void createOverLimitLangList() {
+        overLimitLang = new ArrayList<>();
+        overLimitLang.add(KOREAN);
+        overLimitLang.add(ENGLISH);
+        overLimitLang.add(FRENCH);
+        overLimitLang.add(SPANISH);
+        overLimitLang.add(RUSSIAN);
+        overLimitLang.add(GERMAN);
+        overLimitLang.add(ITALIAN);
+        overLimitLang.add(CHINESE_CANTONESE);
+        overLimitLang.add(CHINESE_MANDARIN);
+        overLimitLang.add(ARABIC);
+        overLimitLang.add(DUTCH);
+        overLimitLang.add(PORTUGUESE);
+        overLimitLang.add(HINDI);
+        overLimitLang.add(JAPANESE);
+        overLimitLang.add(BULGARIAN);
+        overLimitLang.add(SWEDISH);
+        overLimitLang.add(OTHER);
+    }
+
+    @Test
+    @DisplayName("최대로 등록 가능한 언어 개수(16) 내로 삭제 요청이 들어올 시 등록된 언어 삭제에 성공합니다.")
+    public void deleteLanguageSuccess() {
+        languageService.addLanguages(user, newLearningLangRequest, LanguageStatus.LEARNING);
+        languageService.addLanguages(user, newCanSpeakLangRequest, LanguageStatus.CAN_SPEAK);
+        languageService.addLanguages(user, newNativeLangRequest, LanguageStatus.NATIVE);
+
+        List<LanguageData> allLang = languageService.getLanguages(user);
+        List<Integer> langIds = allLang.stream()
+                                        .map(langId -> allLang.get(allLang.indexOf(langId)).getId())
+                                        .collect(Collectors.toList());
+
+        languageService.deleteLanguages(user, langIds);
+
+        List<LanguageData> allLangAfterDelete = languageService.getLanguages(user);
+        assertSame(allLangAfterDelete.size(), 0);
+    }
+
+    @Test
+    @DisplayName("여러 사용가 같은 언어를 등록했다고 하더라도 해당 사용자가 요청한 언어에 대한 정보만 삭제합니다.")
+    public void checkDeleteProperlyByUserId() {
+        String anotherUser = "another";
+
+        // user 의 언어 등록 (총 12개)
+        languageService.addLanguages(user, newLearningLangRequest, LanguageStatus.LEARNING);
+        languageService.addLanguages(user, newCanSpeakLangRequest, LanguageStatus.CAN_SPEAK);
+        languageService.addLanguages(user, newNativeLangRequest, LanguageStatus.NATIVE);
+
+        // anotherUser 의 언어 등록 (user 와 똑같은 언어, 총 12개)
+        languageService.addLanguages(anotherUser, newLearningLangRequest, LanguageStatus.LEARNING);
+        languageService.addLanguages(anotherUser, newCanSpeakLangRequest, LanguageStatus.CAN_SPEAK);
+        languageService.addLanguages(anotherUser, newNativeLangRequest, LanguageStatus.NATIVE);
+
+        languageService.deleteLanguages(user, langInDB);
+
+        List<LanguageData> userLangInDB = languageService.getLanguages(user);
+        List<LanguageData> anotherUserLangInDB = languageService.getLanguages(anotherUser);
+
+        assertTrue(userLangInDB.isEmpty());
+        assertSame(anotherUserLangInDB.size(), 12);
+
+        List<Integer> anotherUserLang = anotherUserLangInDB.stream()
+                .map(langId -> anotherUserLangInDB.get(anotherUserLangInDB.indexOf(langId)).getId())
+                .collect(Collectors.toList());
+
+        boolean isNotDeleted = langInDB.containsAll(anotherUserLang);
+        assertTrue(isNotDeleted);
+    }
+
+    @Test
+    @DisplayName("최대로 등록 가능한 언어 개수(16) 이상으로 언어 삭제 요청이 들어올 시 LanguageLimitExceededException 이 발생하며 삭제에 실패합니다.")
+    public void deleteLanguagesFailOverTotalLanguageLimit() {
+        assertThrows(LanguageLimitExceededException.class, () -> {
+                languageService.deleteLanguages(user, overLimitLang);
+        });
+    }
+
+}

--- a/src/test/java/me/soo/helloworld/service/language/ModifyLevelTestIntegration.java
+++ b/src/test/java/me/soo/helloworld/service/language/ModifyLevelTestIntegration.java
@@ -101,8 +101,8 @@ public class ModifyLevelTestIntegration {
         languageService.addLanguages(userId, learningLang, LanguageStatus.LEARNING);
         languageService.addLanguages(userId, canSpeakLang, LanguageStatus.CAN_SPEAK);
 
-        languageService.modifyLevel(userId, learningLangValidLevelSet, LanguageStatus.LEARNING);
-        languageService.modifyLevel(userId, canSpeakLangValidLevelSet, LanguageStatus.CAN_SPEAK);
+        languageService.modifyLanguageLevels(userId, learningLangValidLevelSet, LanguageStatus.LEARNING);
+        languageService.modifyLanguageLevels(userId, canSpeakLangValidLevelSet, LanguageStatus.CAN_SPEAK);
 
         List<LanguageData> languageList = languageService.getLanguages(userId);
 
@@ -120,11 +120,11 @@ public class ModifyLevelTestIntegration {
         languageService.addLanguages(userId, canSpeakLang, LanguageStatus.CAN_SPEAK);
 
         assertThrows(InvalidLanguageLevelException.class, () -> {
-            languageService.modifyLevel(userId, learningLangInvalidLevelSet, LanguageStatus.LEARNING);
+            languageService.modifyLanguageLevels(userId, learningLangInvalidLevelSet, LanguageStatus.LEARNING);
         });
 
         assertThrows(InvalidLanguageLevelException.class, () -> {
-            languageService.modifyLevel(userId, canSpeakLangInValidLevelSet, LanguageStatus.CAN_SPEAK);
+            languageService.modifyLanguageLevels(userId, canSpeakLangInValidLevelSet, LanguageStatus.CAN_SPEAK);
         });
     }
 
@@ -134,7 +134,7 @@ public class ModifyLevelTestIntegration {
         languageService.addLanguages(userId, nativeLang, LanguageStatus.NATIVE);
 
         assertThrows(InvalidLanguageLevelException.class, () -> {
-            languageService.modifyLevel(userId, nativeLang, LanguageStatus.NATIVE);
+            languageService.modifyLanguageLevels(userId, nativeLang, LanguageStatus.NATIVE);
         });
     }
 }

--- a/src/test/java/me/soo/helloworld/service/language/TestLangId.java
+++ b/src/test/java/me/soo/helloworld/service/language/TestLangId.java
@@ -30,4 +30,10 @@ public class TestLangId {
 
     final static int JAPANESE = 14;
 
+    final static int BULGARIAN = 15;
+
+    final static int SWEDISH = 16;
+
+    final static int OTHER = 17;
+
 }


### PR DESCRIPTION
## Controller 계층 관련

### LanguageController (new)

- `deleteLanguages` 메소드 추가

: 사용자의 언어 삭제 요청을 전달 받을 메소드

## Service 계층 관련

### LanguageService (new)

- `deleteLanguages` 메소드 추가

1) Controller 가 받은 `삭제 요청`을 전달 받아서 처리하기 위한 메소드

2)  최대로 등록 가능한 언어 수를 초과한 삭제요청이 들어올 시 예외 발생

## Repository/Mapper 계층 관련

### LanguageMapper (new)

- `deleteLanguages` 메소드 추가

: 서비스 계층에서 전달 받은 언어 데이터를 가지고 DB에서 삭제를 처리할
메소드

### LanguageMapper.xml (new)

- 위의 로직에 맞는 `Delete 쿼리` 추가

## Test 관련

- 언어 삭제 관련 로직을 테스트하기 위한 서비스 계층 통합 테스트 작성

1) 최대 추가 가능한 언어 수 제한(16개)를 넘지 않는 경우 삭제 처리가
   이루어 지는지 테스트

2) 언어 ID 뿐만 아니라 해당 사용자의 아이디가 일치하는 언어만 삭제가 이루어지는지 테스트

3) 최대 추가 가능한 언어 수의 제한을 넘는 삭제 요청이 들어오면 예외가
   제대로 발생하는지 테스트

- 포스트맨을 활용해 전체적으로 테스트