### PR TITLE
[#13] 친구추가 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/me/soo/helloworld/config/MyBatisConfig.java
+++ b/src/main/java/me/soo/helloworld/config/MyBatisConfig.java
@@ -1,5 +1,6 @@
 package me.soo.helloworld.config;
 
+import me.soo.helloworld.enumeration.FriendStatus;
 import me.soo.helloworld.enumeration.LanguageLevel;
 import me.soo.helloworld.enumeration.LanguageStatus;
 import me.soo.helloworld.mapper.UserMapper;
@@ -26,7 +27,8 @@ public class MyBatisConfig {
         PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
         sessionFactory.setMapperLocations(resolver.getResources("/mappers/*.xml"));
 
-        sessionFactory.setTypeHandlers(new LanguageLevel.TypeHandler(), new LanguageStatus.TypeHandler());
+        sessionFactory.setTypeHandlers(new LanguageLevel.TypeHandler(), new LanguageStatus.TypeHandler(),
+                                        new FriendStatus.TypeHandler());
 
         return sessionFactory.getObject();
     }

--- a/src/main/java/me/soo/helloworld/controller/FriendController.java
+++ b/src/main/java/me/soo/helloworld/controller/FriendController.java
@@ -3,8 +3,7 @@ package me.soo.helloworld.controller;
 import lombok.RequiredArgsConstructor;
 import me.soo.helloworld.annotation.CurrentUser;
 import me.soo.helloworld.service.FriendService;
-import me.soo.helloworld.util.http.HttpResponses;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,10 +13,11 @@ public class FriendController {
 
     private final FriendService friendService;
 
-    @PostMapping("/request/{anotherUserId}")
-    public ResponseEntity<Void> sendFriendRequest(@CurrentUser String userId, @PathVariable String anotherUserId) {
-        friendService.sendFriendRequest(userId, anotherUserId);
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/friend-requests/to/{targetId}")
+    public void sendFriendRequest(@CurrentUser String userId, @PathVariable String targetId) {
 
-        return HttpResponses.HTTP_RESPONSE_CREATED;
+        friendService.sendFriendRequest(userId, targetId);
+
     }
 }

--- a/src/main/java/me/soo/helloworld/controller/FriendController.java
+++ b/src/main/java/me/soo/helloworld/controller/FriendController.java
@@ -1,0 +1,23 @@
+package me.soo.helloworld.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.soo.helloworld.annotation.CurrentUser;
+import me.soo.helloworld.service.FriendService;
+import me.soo.helloworld.util.http.HttpResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/friends")
+public class FriendController {
+
+    private final FriendService friendService;
+
+    @PostMapping("/request/{anotherUserId}")
+    public ResponseEntity<Void> sendFriendRequest(@CurrentUser String userId, @PathVariable String anotherUserId) {
+        friendService.sendFriendRequest(userId, anotherUserId);
+
+        return HttpResponses.HTTP_RESPONSE_CREATED;
+    }
+}

--- a/src/main/java/me/soo/helloworld/controller/UserController.java
+++ b/src/main/java/me/soo/helloworld/controller/UserController.java
@@ -32,7 +32,7 @@ public class UserController {
     @GetMapping("/idcheck")
     public ResponseEntity<Void> isUserIdDuplicate(@RequestParam String userId) {
 
-        if (userService.doesUserIdExist(userId)) {
+        if (userService.isUserIdExist(userId)) {
             return HTTP_RESPONSE_CONFLICT;
         }
 

--- a/src/main/java/me/soo/helloworld/controller/UserController.java
+++ b/src/main/java/me/soo/helloworld/controller/UserController.java
@@ -1,7 +1,6 @@
 package me.soo.helloworld.controller;
 
 import lombok.RequiredArgsConstructor;
-import me.soo.helloworld.annotation.CurrentUser;
 import me.soo.helloworld.model.user.*;
 import me.soo.helloworld.service.LoginService;
 import me.soo.helloworld.service.UserService;

--- a/src/main/java/me/soo/helloworld/controller/UserController.java
+++ b/src/main/java/me/soo/helloworld/controller/UserController.java
@@ -32,7 +32,7 @@ public class UserController {
     @GetMapping("/idcheck")
     public ResponseEntity<Void> isUserIdDuplicate(@RequestParam String userId) {
 
-        if (userService.isUserIdDuplicate(userId)) {
+        if (userService.doesUserIdExist(userId)) {
             return HTTP_RESPONSE_CONFLICT;
         }
 

--- a/src/main/java/me/soo/helloworld/enumeration/FriendStatus.java
+++ b/src/main/java/me/soo/helloworld/enumeration/FriendStatus.java
@@ -1,0 +1,27 @@
+package me.soo.helloworld.enumeration;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import me.soo.helloworld.util.handler.EnumCategoryTypeHandler;
+import org.apache.ibatis.type.MappedTypes;
+
+@Getter
+@RequiredArgsConstructor
+public enum FriendStatus implements EnumCategory {
+
+    NOT_YET(1),
+    REQUESTED(2),
+    RECEIVED(3),
+    FRIENDED(4),
+    BLOCKED(5);
+
+    private final int category;
+
+    @MappedTypes(FriendStatus.class)
+    public static class TypeHandler extends EnumCategoryTypeHandler<FriendStatus> {
+
+        public TypeHandler() {
+            super(FriendStatus.class);
+        }
+    }
+}

--- a/src/main/java/me/soo/helloworld/exception/DuplicateFriendRequestException.java
+++ b/src/main/java/me/soo/helloworld/exception/DuplicateFriendRequestException.java
@@ -1,0 +1,12 @@
+package me.soo.helloworld.exception;
+
+public class DuplicateFriendRequestException extends RuntimeException {
+
+    public DuplicateFriendRequestException(String message) {
+        super(message);
+    }
+
+    public DuplicateFriendRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/me/soo/helloworld/exception/InvalidFriendRequestException.java
+++ b/src/main/java/me/soo/helloworld/exception/InvalidFriendRequestException.java
@@ -1,0 +1,12 @@
+package me.soo.helloworld.exception;
+
+public class InvalidFriendRequestException extends RuntimeException {
+
+    public InvalidFriendRequestException(String message) {
+        super(message);
+    }
+
+    public InvalidFriendRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/me/soo/helloworld/mapper/FriendMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/FriendMapper.java
@@ -6,9 +6,9 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface FriendMapper {
 
-    public void sendFriendRequest(String userId, String anotherUserId);
+    public void sendFriendRequest(String userId, String targetId);
 
-    public FriendStatus getFriendStatus(String userId, String anotherUserId);
+    public FriendStatus getFriendStatus(String userId, String targetId);
 
 
 }

--- a/src/main/java/me/soo/helloworld/mapper/FriendMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/FriendMapper.java
@@ -1,0 +1,14 @@
+package me.soo.helloworld.mapper;
+
+import me.soo.helloworld.enumeration.FriendStatus;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface FriendMapper {
+
+    public void sendFriendRequest(String userId, String anotherUserId);
+
+    public FriendStatus getFriendStatus(String userId, String anotherUserId);
+
+
+}

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -5,6 +5,7 @@ import me.soo.helloworld.enumeration.FriendStatus;
 import me.soo.helloworld.exception.DuplicateFriendRequestException;
 import me.soo.helloworld.exception.InvalidFriendRequestException;
 import me.soo.helloworld.mapper.FriendMapper;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,23 +16,23 @@ public class FriendService {
 
     private final FriendMapper friendMapper;
 
-    public void sendFriendRequest(String userId, String anotherUserId) {
-        if (userId.equals(anotherUserId)) {
+    public void sendFriendRequest(String userId, String targetId) {
+        if (StringUtils.equals(userId, targetId)) {
             throw new InvalidFriendRequestException("자기 자신에게는 친구추가 요청을 보낼 수 없습니다.");
         }
 
-        if (!userService.isUserIdDuplicate(anotherUserId)) {
+        if (!userService.doesUserIdExist(targetId)) {
             throw new InvalidFriendRequestException("존재하지 않는 사용자에게 친구추가 요청을 보낼 수 없습니다.");
         }
 
-        FriendStatus friendStatus = getFriendStatus(userId, anotherUserId);
+        FriendStatus friendStatus = getFriendStatus(userId, targetId);
         isStatusValid(friendStatus);
 
-        friendMapper.sendFriendRequest(userId, anotherUserId);
+        friendMapper.sendFriendRequest(userId, targetId);
     }
 
-    public FriendStatus getFriendStatus(String userId, String anotherUserId) {
-        return friendMapper.getFriendStatus(userId, anotherUserId);
+    public FriendStatus getFriendStatus(String userId, String targetId) {
+        return friendMapper.getFriendStatus(userId, targetId);
     }
 
     private void isStatusValid(FriendStatus status) {

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -21,7 +21,7 @@ public class FriendService {
             throw new InvalidFriendRequestException("자기 자신에게는 친구추가 요청을 보낼 수 없습니다.");
         }
 
-        if (!userService.doesUserIdExist(targetId)) {
+        if (!userService.isUserIdExist(targetId)) {
             throw new InvalidFriendRequestException("존재하지 않는 사용자에게 친구추가 요청을 보낼 수 없습니다.");
         }
 

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -1,0 +1,51 @@
+package me.soo.helloworld.service;
+
+import lombok.RequiredArgsConstructor;
+import me.soo.helloworld.enumeration.FriendStatus;
+import me.soo.helloworld.exception.DuplicateFriendRequestException;
+import me.soo.helloworld.exception.InvalidFriendRequestException;
+import me.soo.helloworld.mapper.FriendMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FriendService {
+
+    private final UserService userService;
+
+    private final FriendMapper friendMapper;
+
+    public void sendFriendRequest(String userId, String anotherUserId) {
+        if (userId.equals(anotherUserId)) {
+            throw new InvalidFriendRequestException("자기 자신에게는 친구추가 요청을 보낼 수 없습니다.");
+        }
+
+        if (!userService.isUserIdDuplicate(anotherUserId)) {
+            throw new InvalidFriendRequestException("존재하지 않는 사용자에게 친구추가 요청을 보낼 수 없습니다.");
+        }
+
+        FriendStatus friendStatus = getFriendStatus(userId, anotherUserId);
+        isStatusValid(friendStatus);
+
+        friendMapper.sendFriendRequest(userId, anotherUserId);
+    }
+
+    public FriendStatus getFriendStatus(String userId, String anotherUserId) {
+        return friendMapper.getFriendStatus(userId, anotherUserId);
+    }
+
+    private void isStatusValid(FriendStatus status) {
+        switch (status) {
+            case NOT_YET:
+                break;
+            case REQUESTED:
+                throw new DuplicateFriendRequestException("이미 친구요청을 보낸 사용자에게 다시 친구 요청을 보낼 수 없습니다.");
+            case RECEIVED:
+                throw new DuplicateFriendRequestException("이미 해당 사용자로부터 친구추가 요청을 받은 상태입니다. 받은 친구 요청을 다시 확인해주세요.");
+            case FRIENDED:
+                throw new DuplicateFriendRequestException("이미 친구로 등록된 사용자에게 다시 친구 요청을 보낼 수 없습니다.");
+            case BLOCKED:
+                throw new InvalidFriendRequestException("차단한 사용자에게 친구 요청을 보낼 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/me/soo/helloworld/service/UserService.java
+++ b/src/main/java/me/soo/helloworld/service/UserService.java
@@ -30,7 +30,7 @@ public class UserService {
         userRepository.insertUser(user.buildUserWithEncodedPassword(encodedPassword));
     }
 
-    public boolean isUserIdDuplicate(String userId) {
+    public boolean doesUserIdExist(String userId) {
         return userRepository.isUserIdDuplicate(userId);
     }
 

--- a/src/main/java/me/soo/helloworld/service/UserService.java
+++ b/src/main/java/me/soo/helloworld/service/UserService.java
@@ -30,7 +30,7 @@ public class UserService {
         userRepository.insertUser(user.buildUserWithEncodedPassword(encodedPassword));
     }
 
-    public boolean doesUserIdExist(String userId) {
+    public boolean isUserIdExist(String userId) {
         return userRepository.isUserIdDuplicate(userId);
     }
 

--- a/src/main/java/me/soo/helloworld/util/handler/ControllerExceptionHandler.java
+++ b/src/main/java/me/soo/helloworld/util/handler/ControllerExceptionHandler.java
@@ -56,4 +56,13 @@ public class ControllerExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler({
+            InvalidFriendRequestException.class,
+            DuplicateFriendRequestException.class
+    })
+    public ResponseEntity<ExceptionResponse> friendRequestException(final RuntimeException ex) {
+        log.error(ex.getMessage(), ex);
+        ExceptionResponse response = new ExceptionResponse("친구 추가 요청을 보내는데 실패하였습니다.", ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/resources/mappers/FriendMapper.xml
+++ b/src/main/resources/mappers/FriendMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="me.soo.helloworld.mapper.FriendMapper">
+
+    <insert id="sendFriendRequest" parameterType="String">
+
+        INSERT INTO friends (userId, friendId, status)
+            VALUES (#{userId}, #{anotherUserId}, 2), (#{anotherUserId}, #{userId}, 3)
+    </insert>
+
+    <select id="getFriendStatus" parameterType="String" resultType="me.soo.helloworld.enumeration.FriendStatus">
+
+        SELECT IFNULL(MAX(status), 1)
+            FROM friends WHERE userId = #{userId} AND friendId = #{anotherUserId}
+    </select>
+
+</mapper>

--- a/src/main/resources/mappers/FriendMapper.xml
+++ b/src/main/resources/mappers/FriendMapper.xml
@@ -6,13 +6,13 @@
     <insert id="sendFriendRequest" parameterType="String">
 
         INSERT INTO friends (userId, friendId, status)
-            VALUES (#{userId}, #{anotherUserId}, 2), (#{anotherUserId}, #{userId}, 3)
+            VALUES (#{userId}, #{targetId}, 2), (#{targetId}, #{userId}, 3)
     </insert>
 
     <select id="getFriendStatus" parameterType="String" resultType="me.soo.helloworld.enumeration.FriendStatus">
 
         SELECT IFNULL(MAX(status), 1)
-            FROM friends WHERE userId = #{userId} AND friendId = #{anotherUserId}
+            FROM friends WHERE userId = #{userId} AND friendId = #{targetId}
     </select>
 
 </mapper>

--- a/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
@@ -53,34 +53,34 @@ public class FriendServiceTest {
     @Test
     @DisplayName("존재하지 않는 사용자에게 친구 추가 요청을 보낼 경우 InvalidRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToNonExistentUserFail() {
-        when(userService.doesUserIdExist(anotherUserId)).thenReturn(false);
+        when(userService.isUserIdExist(anotherUserId)).thenReturn(false);
 
         assertThrows(InvalidFriendRequestException.class, () -> {
             friendService.sendFriendRequest(userId, anotherUserId);
         });
 
-        verify(userService, times(1)).doesUserIdExist(anotherUserId);
+        verify(userService, times(1)).isUserIdExist(anotherUserId);
         verify(friendMapper, never()).getFriendStatus(userId, anotherUserId);
     }
 
     @Test
     @DisplayName("차단한 사용자에게 친구 추가 요청을 보낼 경우 InvalidRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToBlockedUserFail() {
-        when(userService.doesUserIdExist(anotherUserId)).thenReturn(true);
+        when(userService.isUserIdExist(anotherUserId)).thenReturn(true);
         when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.BLOCKED);
 
         assertThrows(InvalidFriendRequestException.class, () -> {
             friendService.sendFriendRequest(userId, anotherUserId);
         });
 
-        verify(userService, times(1)).doesUserIdExist(anotherUserId);
+        verify(userService, times(1)).isUserIdExist(anotherUserId);
         verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
     }
 
     @Test
     @DisplayName("이미 친구 추가 요청을 보낸 사용자에게 다시 친구 추가 요청을 보낼 경우 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestWithDuplicateFriendRequestFail() {
-        when(userService.doesUserIdExist(anotherUserId)).thenReturn(true);
+        when(userService.isUserIdExist(anotherUserId)).thenReturn(true);
         when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.REQUESTED);
 
         assertThrows(DuplicateFriendRequestException.class, () -> {
@@ -93,40 +93,40 @@ public class FriendServiceTest {
     @Test
     @DisplayName("한 사용자로부터 받은 친구 추가 요청을 수락하지 않은 상태에서 해당 사용자에게 다시 친구 추가 요청을 보내면 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToWhomAlreadySentMeRequestFail() {
-        when(userService.doesUserIdExist(anotherUserId)).thenReturn(true);
+        when(userService.isUserIdExist(anotherUserId)).thenReturn(true);
         when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.RECEIVED);
 
         assertThrows(DuplicateFriendRequestException.class, () -> {
             friendService.sendFriendRequest(userId, anotherUserId);
         });
 
-        verify(userService, times(1)).doesUserIdExist(anotherUserId);
+        verify(userService, times(1)).isUserIdExist(anotherUserId);
         verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
     }
 
     @Test
     @DisplayName("이미 친구 추가 되어 있는 사용자에게 다시 친구 추가 요청을 보내면 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToAlreadyFriendUserFail() {
-        when(userService.doesUserIdExist(anotherUserId)).thenReturn(true);
+        when(userService.isUserIdExist(anotherUserId)).thenReturn(true);
         when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.FRIENDED);
 
         assertThrows(DuplicateFriendRequestException.class, () -> {
             friendService.sendFriendRequest(userId, anotherUserId);
         });
 
-        verify(userService, times(1)).doesUserIdExist(anotherUserId);
+        verify(userService, times(1)).isUserIdExist(anotherUserId);
         verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
     }
 
     @Test
     @DisplayName("다른 사용자에게 중복된 친구 요청을 보내거나 잘못된 사용자에게 친구요청을 보내는 경우가 아니면 친구 요청을 보내는데 성공합니다.")
     public void sendFriendRequestToValidUserSuccess() {
-        when(userService.doesUserIdExist(anotherUserId)).thenReturn(true);
+        when(userService.isUserIdExist(anotherUserId)).thenReturn(true);
         when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.NOT_YET);
 
         friendService.sendFriendRequest(userId, anotherUserId);
 
-        verify(userService, times(1)).doesUserIdExist(anotherUserId);
+        verify(userService, times(1)).isUserIdExist(anotherUserId);
         verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
     }
 }

--- a/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
@@ -53,34 +53,34 @@ public class FriendServiceTest {
     @Test
     @DisplayName("존재하지 않는 사용자에게 친구 추가 요청을 보낼 경우 InvalidRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToNonExistentUserFail() {
-        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(false);
+        when(userService.doesUserIdExist(anotherUserId)).thenReturn(false);
 
         assertThrows(InvalidFriendRequestException.class, () -> {
             friendService.sendFriendRequest(userId, anotherUserId);
         });
 
-        verify(userService, times(1)).isUserIdDuplicate(anotherUserId);
+        verify(userService, times(1)).doesUserIdExist(anotherUserId);
         verify(friendMapper, never()).getFriendStatus(userId, anotherUserId);
     }
 
     @Test
     @DisplayName("차단한 사용자에게 친구 추가 요청을 보낼 경우 InvalidRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToBlockedUserFail() {
-        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(true);
+        when(userService.doesUserIdExist(anotherUserId)).thenReturn(true);
         when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.BLOCKED);
 
         assertThrows(InvalidFriendRequestException.class, () -> {
             friendService.sendFriendRequest(userId, anotherUserId);
         });
 
-        verify(userService, times(1)).isUserIdDuplicate(anotherUserId);
+        verify(userService, times(1)).doesUserIdExist(anotherUserId);
         verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
     }
 
     @Test
     @DisplayName("이미 친구 추가 요청을 보낸 사용자에게 다시 친구 추가 요청을 보낼 경우 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestWithDuplicateFriendRequestFail() {
-        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(true);
+        when(userService.doesUserIdExist(anotherUserId)).thenReturn(true);
         when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.REQUESTED);
 
         assertThrows(DuplicateFriendRequestException.class, () -> {
@@ -93,40 +93,40 @@ public class FriendServiceTest {
     @Test
     @DisplayName("한 사용자로부터 받은 친구 추가 요청을 수락하지 않은 상태에서 해당 사용자에게 다시 친구 추가 요청을 보내면 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToWhomAlreadySentMeRequestFail() {
-        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(true);
+        when(userService.doesUserIdExist(anotherUserId)).thenReturn(true);
         when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.RECEIVED);
 
         assertThrows(DuplicateFriendRequestException.class, () -> {
             friendService.sendFriendRequest(userId, anotherUserId);
         });
 
-        verify(userService, times(1)).isUserIdDuplicate(anotherUserId);
+        verify(userService, times(1)).doesUserIdExist(anotherUserId);
         verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
     }
 
     @Test
     @DisplayName("이미 친구 추가 되어 있는 사용자에게 다시 친구 추가 요청을 보내면 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToAlreadyFriendUserFail() {
-        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(true);
+        when(userService.doesUserIdExist(anotherUserId)).thenReturn(true);
         when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.FRIENDED);
 
         assertThrows(DuplicateFriendRequestException.class, () -> {
             friendService.sendFriendRequest(userId, anotherUserId);
         });
 
-        verify(userService, times(1)).isUserIdDuplicate(anotherUserId);
+        verify(userService, times(1)).doesUserIdExist(anotherUserId);
         verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
     }
 
     @Test
     @DisplayName("다른 사용자에게 중복된 친구 요청을 보내거나 잘못된 사용자에게 친구요청을 보내는 경우가 아니면 친구 요청을 보내는데 성공합니다.")
     public void sendFriendRequestToValidUserSuccess() {
-        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(true);
+        when(userService.doesUserIdExist(anotherUserId)).thenReturn(true);
         when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.NOT_YET);
 
         friendService.sendFriendRequest(userId, anotherUserId);
 
-        verify(userService, times(1)).isUserIdDuplicate(anotherUserId);
+        verify(userService, times(1)).doesUserIdExist(anotherUserId);
         verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
     }
 }

--- a/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
@@ -1,0 +1,132 @@
+package me.soo.helloworld.service;
+
+import me.soo.helloworld.enumeration.FriendStatus;
+import me.soo.helloworld.exception.DuplicateFriendRequestException;
+import me.soo.helloworld.exception.InvalidFriendRequestException;
+import me.soo.helloworld.mapper.FriendMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class FriendServiceTest {
+
+    private final String userId = "Soo1045";
+
+    private final String anotherUserId = "ImNotSoo1045";
+
+    @InjectMocks
+    FriendService friendService;
+
+    @Mock
+    FriendMapper friendMapper;
+
+    @Mock
+    UserService userService;
+
+    /*
+        친구 요청을 보낼 때 발생할 수 있는 예외들
+
+        - 요청을 보낼 사용자가 존재하지 않는 경우
+        - 친구 요청을 자기 자신에게 보내는 경우
+        - 자신이 차단한 사용자에 대해 친구 요청을 보내는 경우
+        - 이미 친구 요청을 보낸 유저에게 다시 친구 요청을 보내는 경우
+        - 다른 사용자가 보낸 친구 요청을 수락하기 전에 다시 그 사용자에게 친구 요청을 보내는 경우
+        - 이미 친구인 유저에게 요청을 다시 보내는 경우
+     */
+    @Test
+    @DisplayName("자기 자신에게 친구 추가 요청을 보낼 경우 InvalidRequestException 이 발생하며 요청에 실패합니다.")
+    public void sendFriendRequestToMyselfFail() {
+        assertThrows(InvalidFriendRequestException.class, () -> {
+           friendService.sendFriendRequest(userId, userId);
+        });
+
+        verify(friendMapper, never()).getFriendStatus(userId, anotherUserId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자에게 친구 추가 요청을 보낼 경우 InvalidRequestException 이 발생하며 요청에 실패합니다.")
+    public void sendFriendRequestToNonExistentUserFail() {
+        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(false);
+
+        assertThrows(InvalidFriendRequestException.class, () -> {
+            friendService.sendFriendRequest(userId, anotherUserId);
+        });
+
+        verify(userService, times(1)).isUserIdDuplicate(anotherUserId);
+        verify(friendMapper, never()).getFriendStatus(userId, anotherUserId);
+    }
+
+    @Test
+    @DisplayName("자기 자신에게 친구 추가 요청을 보낼 경우 InvalidRequestException 이 발생하며 요청에 실패합니다.")
+    public void sendFriendRequestToBlockedUserFail() {
+        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(true);
+        when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.BLOCKED);
+
+        assertThrows(InvalidFriendRequestException.class, () -> {
+            friendService.sendFriendRequest(userId, anotherUserId);
+        });
+
+        verify(userService, times(1)).isUserIdDuplicate(anotherUserId);
+        verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
+    }
+
+    @Test
+    @DisplayName("이미 친구 추가 요청을 보낸 사용자에게 다시 친구 추가 요청을 보낼 경우 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
+    public void sendFriendRequestWithDuplicateFriendRequestFail() {
+        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(true);
+        when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.REQUESTED);
+
+        assertThrows(DuplicateFriendRequestException.class, () -> {
+            friendService.sendFriendRequest(userId, anotherUserId);
+        });
+
+        verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
+    }
+
+    @Test
+    @DisplayName("한 사용자로부터 받은 친구 추가 요청을 수락하지 않은 상태에서 해당 사용자에게 다시 친구 추가 요청을 보내면 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
+    public void sendFriendRequestToWhomAlreadySentMeRequestFail() {
+        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(true);
+        when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.RECEIVED);
+
+        assertThrows(DuplicateFriendRequestException.class, () -> {
+            friendService.sendFriendRequest(userId, anotherUserId);
+        });
+
+        verify(userService, times(1)).isUserIdDuplicate(anotherUserId);
+        verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
+    }
+
+    @Test
+    @DisplayName("이미 친구 추가 되어 있는 사용자에게 다시 친구 추가 요청을 보내면 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
+    public void sendFriendRequestToAlreadyFriendUserFail() {
+        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(true);
+        when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.FRIENDED);
+
+        assertThrows(DuplicateFriendRequestException.class, () -> {
+            friendService.sendFriendRequest(userId, anotherUserId);
+        });
+
+        verify(userService, times(1)).isUserIdDuplicate(anotherUserId);
+        verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
+    }
+
+    @Test
+    @DisplayName("다른 사용자에게 중복된 친구 요청을 보내거나 잘못된 사용자에게 친구요청을 보내는 경우가 아니면 친구 요청을 보내는데 성공합니다.")
+    public void sendFriendRequestToValidUserSuccess() {
+        when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(true);
+        when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.NOT_YET);
+
+        friendService.sendFriendRequest(userId, anotherUserId);
+
+        verify(userService, times(1)).isUserIdDuplicate(anotherUserId);
+        verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
+    }
+}

--- a/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
@@ -64,7 +64,7 @@ public class FriendServiceTest {
     }
 
     @Test
-    @DisplayName("자기 자신에게 친구 추가 요청을 보낼 경우 InvalidRequestException 이 발생하며 요청에 실패합니다.")
+    @DisplayName("차단한 사용자에게 친구 추가 요청을 보낼 경우 InvalidRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToBlockedUserFail() {
         when(userService.isUserIdDuplicate(anotherUserId)).thenReturn(true);
         when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.BLOCKED);

--- a/src/test/java/me/soo/helloworld/service/user/UserServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/user/UserServiceTest.java
@@ -66,7 +66,7 @@ class UserServiceTest {
     public void duplicateUserIdExceptionFalse() {
         when(userRepository.isUserIdDuplicate(testUser.getUserId())).thenReturn(false);
 
-        assertThat(userService.doesUserIdExist(testUser.getUserId()), is(false));
+        assertThat(userService.isUserIdExist(testUser.getUserId()), is(false));
 
         verify(userRepository, times(1)).isUserIdDuplicate(testUser.getUserId());
     }
@@ -76,7 +76,7 @@ class UserServiceTest {
     public void duplicateUserIdExceptionTrue() {
         when(userRepository.isUserIdDuplicate(testUser.getUserId())).thenReturn(true);
 
-        assertThat(userService.doesUserIdExist(testUser.getUserId()), is(true));
+        assertThat(userService.isUserIdExist(testUser.getUserId()), is(true));
 
         verify(userRepository, times(1)).isUserIdDuplicate(testUser.getUserId());
     }

--- a/src/test/java/me/soo/helloworld/service/user/UserServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/user/UserServiceTest.java
@@ -66,7 +66,7 @@ class UserServiceTest {
     public void duplicateUserIdExceptionFalse() {
         when(userRepository.isUserIdDuplicate(testUser.getUserId())).thenReturn(false);
 
-        assertThat(userService.isUserIdDuplicate(testUser.getUserId()), is(false));
+        assertThat(userService.doesUserIdExist(testUser.getUserId()), is(false));
 
         verify(userRepository, times(1)).isUserIdDuplicate(testUser.getUserId());
     }
@@ -76,7 +76,7 @@ class UserServiceTest {
     public void duplicateUserIdExceptionTrue() {
         when(userRepository.isUserIdDuplicate(testUser.getUserId())).thenReturn(true);
 
-        assertThat(userService.isUserIdDuplicate(testUser.getUserId()), is(true));
+        assertThat(userService.doesUserIdExist(testUser.getUserId()), is(true));
 
         verify(userRepository, times(1)).isUserIdDuplicate(testUser.getUserId());
     }


### PR DESCRIPTION
## Enum 클래스 관련

### FriendStatus 클래스 추가
- `친구 상태`에 대한 상수, 카테고리 값을 가지고 있는 Enum 클래스

- `TypeHandler`를 사용해서 자동으로 DB 저장시에는 정수 값을, 불러올 때는 상수
  값을 가져올 수 있도록 함

## Controller 계층관련

### FriendController 클래스 추가

- 친구 추가 요청을 받을 `sendFriendRequest` 메소드 추가

## Service 계층 관련

### FriendService 클래스 추가

- 요청에 대한 조건을 검사한 뒤 친구추가 요청을 보낼 `sendFriendRequest` 메소드 추가

  1. 요청을 보낼 사용자의 아이디가 `현재 사용자의 아이디와 같은지` 확인

  2. 요청을 보낼 사용자의 아이디가 `서비스 내에 실제로 존재하는지` 확인

  3. 친구 `status` 값 검사를 통해 `중복/부적절한 요청` 확인
  
  4. `문제 없을 시 친구추가` 요청

## Mapper 계층 관련

### FriendMapper 인터페이스 추가

- 보낸 친구 요청을 DB에 반영하기 위한 `sendFriendRequest` 메소드 추가

- DB에 저장된 친구 status 값을 불러오기 위한 `getFriendStatus` 메소드
  추가

### FriendMapper.xml 파일 추가

- 위의 메소드의 목적에 맞게 동작할 쿼리 문장을 담고 있는 mapper.xml 파일

## Exception 관련

### DuplicateFriendRequestException 클래스 추가

- `중복된 친구 추가 요청`에 대한 예외를 처리하기 위한 클래스

  : `DuplicateRequestException`을 재사용 하려고 했으나 ExceptionHandler가 `vague statement` 오류를 발생시켜 새로운 예외 클래스를 작성

### InvalidFriendRequestException 클래스 추가

- `부적절한 친구 추가 요청`에 대한 예외를 처리하기 위한 클래스

### 해당 예외들을 ControllerExceptionHandler에 매핑

- 위의 예외가 발생 시 예외 메시지와 함께 `Bad Request(400)`을 사용자에게
  리턴

## 테스트 관련

* FriendService 단위 테스트 작성

- FriendService의 `sendFriendRequest` 메소드에 대한 발생가능한 예외/성공 케이스에 대한
단위테스트 작성 및 구동

- Postman 을 활용해 예상 가능한 예외/성공 케이스에 대한 로직이 제대로 작동하는지 확인