### PR TITLE
[#15] 친구추가 요청 철회기능 구현

### DIFF
--- a/src/main/java/me/soo/helloworld/controller/FriendController.java
+++ b/src/main/java/me/soo/helloworld/controller/FriendController.java
@@ -19,7 +19,6 @@ public class FriendController {
         friendService.sendFriendRequest(userId, targetId);
     }
 
-    @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/friend-requests/to/{targetId}")
     public void cancelFriendRequest(@CurrentUser String userId, @PathVariable String targetId) {
         friendService.cancelFriendRequest(userId, targetId);

--- a/src/main/java/me/soo/helloworld/controller/FriendController.java
+++ b/src/main/java/me/soo/helloworld/controller/FriendController.java
@@ -16,8 +16,12 @@ public class FriendController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/friend-requests/to/{targetId}")
     public void sendFriendRequest(@CurrentUser String userId, @PathVariable String targetId) {
-
         friendService.sendFriendRequest(userId, targetId);
+    }
 
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping("/friend-requests/to/{targetId}")
+    public void cancelFriendRequest(@CurrentUser String userId, @PathVariable String targetId) {
+        friendService.cancelFriendRequest(userId, targetId);
     }
 }

--- a/src/main/java/me/soo/helloworld/mapper/FriendMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/FriendMapper.java
@@ -10,5 +10,5 @@ public interface FriendMapper {
 
     public FriendStatus getFriendStatus(String userId, String targetId);
 
-
+    public void deleteFriendRequest(String userId, String targetId);
 }

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -8,6 +8,8 @@ import me.soo.helloworld.mapper.FriendMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
+import static me.soo.helloworld.enumeration.FriendStatus.*;
+
 @Service
 @RequiredArgsConstructor
 public class FriendService {
@@ -48,5 +50,15 @@ public class FriendService {
             case BLOCKED:
                 throw new InvalidFriendRequestException("차단한 사용자에게 친구 요청을 보낼 수 없습니다.");
         }
+    }
+
+    public void cancelFriendRequest(String userId, String targetId) {
+        FriendStatus friendStatus = getFriendStatus(userId, targetId);
+
+        if (!friendStatus.equals(REQUESTED)) {
+            throw new InvalidFriendRequestException("잘못된 접근입니다.");
+        }
+
+        friendMapper.deleteFriendRequest(userId, targetId);
     }
 }

--- a/src/main/resources/mappers/FriendMapper.xml
+++ b/src/main/resources/mappers/FriendMapper.xml
@@ -15,4 +15,11 @@
             FROM friends WHERE userId = #{userId} AND friendId = #{targetId}
     </select>
 
+    <delete id="deleteFriendRequest" parameterType="String">
+
+        DELETE FROM friends
+            WHERE (userId = #{userId} AND friendId = #{targetId})
+                OR (userId = #{targetId} AND friendId = #{userId})
+    </delete>
+
 </mapper>

--- a/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
@@ -13,13 +13,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
+import static me.soo.helloworld.enumeration.FriendStatus.*;
 
 @ExtendWith(MockitoExtension.class)
 public class FriendServiceTest {
 
     private final String userId = "Soo1045";
 
-    private final String anotherUserId = "ImNotSoo1045";
+    private final String targetId = "ImNotSoo1045";
 
     @InjectMocks
     FriendService friendService;
@@ -47,86 +48,149 @@ public class FriendServiceTest {
            friendService.sendFriendRequest(userId, userId);
         });
 
-        verify(friendMapper, never()).getFriendStatus(userId, anotherUserId);
+        verify(friendMapper, never()).getFriendStatus(userId, targetId);
     }
 
     @Test
     @DisplayName("존재하지 않는 사용자에게 친구 추가 요청을 보낼 경우 InvalidRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToNonExistentUserFail() {
-        when(userService.isUserIdExist(anotherUserId)).thenReturn(false);
+        when(userService.isUserIdExist(targetId)).thenReturn(false);
 
         assertThrows(InvalidFriendRequestException.class, () -> {
-            friendService.sendFriendRequest(userId, anotherUserId);
+            friendService.sendFriendRequest(userId, targetId);
         });
 
-        verify(userService, times(1)).isUserIdExist(anotherUserId);
-        verify(friendMapper, never()).getFriendStatus(userId, anotherUserId);
+        verify(userService, times(1)).isUserIdExist(targetId);
+        verify(friendMapper, never()).getFriendStatus(userId, targetId);
     }
 
     @Test
     @DisplayName("차단한 사용자에게 친구 추가 요청을 보낼 경우 InvalidRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToBlockedUserFail() {
-        when(userService.isUserIdExist(anotherUserId)).thenReturn(true);
-        when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.BLOCKED);
+        when(userService.isUserIdExist(targetId)).thenReturn(true);
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(FriendStatus.BLOCKED);
 
         assertThrows(InvalidFriendRequestException.class, () -> {
-            friendService.sendFriendRequest(userId, anotherUserId);
+            friendService.sendFriendRequest(userId, targetId);
         });
 
-        verify(userService, times(1)).isUserIdExist(anotherUserId);
-        verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
+        verify(userService, times(1)).isUserIdExist(targetId);
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
     }
 
     @Test
     @DisplayName("이미 친구 추가 요청을 보낸 사용자에게 다시 친구 추가 요청을 보낼 경우 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestWithDuplicateFriendRequestFail() {
-        when(userService.isUserIdExist(anotherUserId)).thenReturn(true);
-        when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.REQUESTED);
+        when(userService.isUserIdExist(targetId)).thenReturn(true);
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(FriendStatus.REQUESTED);
 
         assertThrows(DuplicateFriendRequestException.class, () -> {
-            friendService.sendFriendRequest(userId, anotherUserId);
+            friendService.sendFriendRequest(userId, targetId);
         });
 
-        verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
     }
 
     @Test
     @DisplayName("한 사용자로부터 받은 친구 추가 요청을 수락하지 않은 상태에서 해당 사용자에게 다시 친구 추가 요청을 보내면 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToWhomAlreadySentMeRequestFail() {
-        when(userService.isUserIdExist(anotherUserId)).thenReturn(true);
-        when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.RECEIVED);
+        when(userService.isUserIdExist(targetId)).thenReturn(true);
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(FriendStatus.RECEIVED);
 
         assertThrows(DuplicateFriendRequestException.class, () -> {
-            friendService.sendFriendRequest(userId, anotherUserId);
+            friendService.sendFriendRequest(userId, targetId);
         });
 
-        verify(userService, times(1)).isUserIdExist(anotherUserId);
-        verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
+        verify(userService, times(1)).isUserIdExist(targetId);
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
     }
 
     @Test
     @DisplayName("이미 친구 추가 되어 있는 사용자에게 다시 친구 추가 요청을 보내면 DuplicateRequestException 이 발생하며 요청에 실패합니다.")
     public void sendFriendRequestToAlreadyFriendUserFail() {
-        when(userService.isUserIdExist(anotherUserId)).thenReturn(true);
-        when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.FRIENDED);
+        when(userService.isUserIdExist(targetId)).thenReturn(true);
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(FriendStatus.FRIENDED);
 
         assertThrows(DuplicateFriendRequestException.class, () -> {
-            friendService.sendFriendRequest(userId, anotherUserId);
+            friendService.sendFriendRequest(userId, targetId);
         });
 
-        verify(userService, times(1)).isUserIdExist(anotherUserId);
-        verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
+        verify(userService, times(1)).isUserIdExist(targetId);
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
     }
 
     @Test
     @DisplayName("다른 사용자에게 중복된 친구 요청을 보내거나 잘못된 사용자에게 친구요청을 보내는 경우가 아니면 친구 요청을 보내는데 성공합니다.")
     public void sendFriendRequestToValidUserSuccess() {
-        when(userService.isUserIdExist(anotherUserId)).thenReturn(true);
-        when(friendMapper.getFriendStatus(userId, anotherUserId)).thenReturn(FriendStatus.NOT_YET);
+        when(userService.isUserIdExist(targetId)).thenReturn(true);
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(FriendStatus.NOT_YET);
 
-        friendService.sendFriendRequest(userId, anotherUserId);
+        friendService.sendFriendRequest(userId, targetId);
 
-        verify(userService, times(1)).isUserIdExist(anotherUserId);
-        verify(friendMapper, times(1)).getFriendStatus(userId, anotherUserId);
+        verify(userService, times(1)).isUserIdExist(targetId);
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
+    }
+
+    @Test
+    @DisplayName("사용자가 보낸 친구 요청의 상태가 REQUESTED 인 경우 보낸 친구요청을 철회하는데 성공합니다.")
+    public void cancelFriendRequestSuccessWithFriendStatusRequested() {
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(REQUESTED);
+
+        friendService.cancelFriendRequest(userId, targetId);
+
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
+        verify(friendMapper, times(1)).deleteFriendRequest(userId, targetId);
+    }
+
+    @Test
+    @DisplayName("사용자가 보낸 친구 요청의 상태가 BLOCKED 인 경우 보낸 InvalidFriendRequestException 이 발생하며 친구요청을 철회하는데 실패합니다.")
+    public void cancelFriendRequestFailWithFriendStatusBlocked() {
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(BLOCKED);
+
+        assertThrows(InvalidFriendRequestException.class, () -> {
+            friendService.cancelFriendRequest(userId, targetId);
+        });
+
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
+        verify(friendMapper, never()).deleteFriendRequest(userId, targetId);
+    }
+
+    @Test
+    @DisplayName("사용자가 보낸 친구 요청의 상태가 NOT_YET 인 경우 보낸 InvalidFriendRequestException 이 발생하며 친구요청을 철회하는데 실패합니다.")
+    public void cancelFriendRequestFailWithFriendStatusNotYet() {
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(NOT_YET);
+
+        assertThrows(InvalidFriendRequestException.class, () -> {
+            friendService.cancelFriendRequest(userId, targetId);
+        });
+
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
+        verify(friendMapper, never()).deleteFriendRequest(userId, targetId);
+    }
+
+    @Test
+    @DisplayName("사용자가 보낸 친구 요청의 상태가 RECEIVED 인 경우 보낸 InvalidFriendRequestException 이 발생하며 친구요청을 철회하는데 실패합니다.")
+    public void cancelFriendRequestFailWithFriendStatusReceived() {
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(RECEIVED);
+
+        assertThrows(InvalidFriendRequestException.class, () -> {
+            friendService.cancelFriendRequest(userId, targetId);
+        });
+
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
+        verify(friendMapper, never()).deleteFriendRequest(userId, targetId);
+    }
+
+    @Test
+    @DisplayName("사용자가 보낸 친구 요청의 상태가 FRIENDED 인 경우 보낸 InvalidFriendRequestException 이 발생하며 친구요청을 철회하는데 실패합니다.")
+    public void cancelFriendRequestFailWithFriendStatusFriended() {
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(FRIENDED);
+
+        assertThrows(InvalidFriendRequestException.class, () -> {
+            friendService.cancelFriendRequest(userId, targetId);
+        });
+
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
+        verify(friendMapper, never()).deleteFriendRequest(userId, targetId);
     }
 }


### PR DESCRIPTION
## FriendController

### `cancelFriendRequest` 메소드 추가

- 친구추가 철회 요청을 받아서 서비스 계층에 전달해 줄 컨트롤러 메소드

## FriendService

### `cancleFriendRequest` 메소드 추가

- 전달 받은 철회 요청을 적합한 요청인지 검사한 뒤 적합하면 요청을 Mapper로  전달

## Friend Mapper

### `deleteFriendRequest` 메소드 추가

- 처리된 비즈니스 로직을 DB에 반영하기 위한 메소드

### FriendMapper.xml에 해당 내용에 관한 쿼리 추가

## 테스트

- 친구추가 철회 요청 로직을 테스트하기 위한 테스트 작성 및 구동

- `PostMan` 을 이용한 테스트