### PR TITLE
[#17] 친구추가 요청 거절 기능 구현

### DIFF
--- a/src/main/java/me/soo/helloworld/controller/FriendController.java
+++ b/src/main/java/me/soo/helloworld/controller/FriendController.java
@@ -30,4 +30,10 @@ public class FriendController {
     public void acceptFriendRequest(@CurrentUser String userId, @PathVariable String targetId) {
         friendService.acceptFriendRequest(userId, targetId);
     }
+
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping("/friend-requests/from/{targetId}/rejection")
+    public void rejectFriendRequest(@CurrentUser String userId, @PathVariable String targetId) {
+        friendService.rejectFriendRequest(userId, targetId);
+    }
 }

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -69,4 +69,10 @@ public class FriendService {
         isStatusValid(friendStatus, RECEIVED);
         friendMapper.updateFriendRequest(userId, targetId, FRIENDED);
     }
+
+    public void rejectFriendRequest(String userId, String targetId) {
+        FriendStatus friendStatus = getFriendStatus(userId, targetId);
+        isStatusValid(friendStatus, RECEIVED);
+        friendMapper.deleteFriendRequest(userId, targetId);
+    }
 }

--- a/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
@@ -257,5 +257,66 @@ public class FriendServiceTest {
         verify(friendMapper, never()).updateFriendRequest(userId, targetId, FRIENDED);
     }
 
+    @Test
+    @DisplayName("사용자가 받은 친구 요청의 상태가 RECEIVED 인 경우에 받은 친구요청을 거절하는데 성공합니다.")
+    public void rejectFriendRequestSuccessWhenFriendStatusReceived() {
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(RECEIVED);
 
+        friendService.rejectFriendRequest(userId, targetId);
+
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
+        verify(friendMapper, times(1)).deleteFriendRequest(userId, targetId);
+    }
+
+    @Test
+    @DisplayName("사용자가 받은 친구 요청의 상태가 BLOCKED 인 경우 InvalidFriendRequestException 이 발생하며 친구요청을 거절하는데 실패합니다.")
+    public void rejectFriendRequestFailIfFriendStatusBlocked() {
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(BLOCKED);
+
+        assertThrows(InvalidFriendRequestException.class, () -> {
+            friendService.rejectFriendRequest(userId, targetId);
+        });
+
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
+        verify(friendMapper, never()).deleteFriendRequest(userId, targetId);
+    }
+
+    @Test
+    @DisplayName("사용자가 받은 친구 요청의 상태가 NOT_YET 인 경우 InvalidFriendRequestException 이 발생하며 친구요청을 거절하는데 실패합니다.")
+    public void rejectFriendRequestFailIfFriendStatusNotYet() {
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(NOT_YET);
+
+        assertThrows(InvalidFriendRequestException.class, () -> {
+            friendService.rejectFriendRequest(userId, targetId);
+        });
+
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
+        verify(friendMapper, never()).deleteFriendRequest(userId, targetId);
+    }
+
+    @Test
+    @DisplayName("사용자가 받은 친구 요청의 상태가 REQUESTED 인 경우 InvalidFriendRequestException 이 발생하며 친구요청을 수락하는데 실패합니다.")
+    public void rejectFriendRequestFailIfFriendStatusRequested() {
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(REQUESTED);
+
+        assertThrows(InvalidFriendRequestException.class, () -> {
+            friendService.rejectFriendRequest(userId, targetId);
+        });
+
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
+        verify(friendMapper, never()).deleteFriendRequest(userId, targetId);
+    }
+
+    @Test
+    @DisplayName("사용자가 보낸 친구 요청의 상태가 이미 FRIENDED 인 경우 보낸 InvalidFriendRequestException 이 발생하며 친구요청을 철회하는데 실패합니다.")
+    public void rejectFriendRequestFailIfFriendStatusAlreadyFriended() {
+        when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(FRIENDED);
+
+        assertThrows(InvalidFriendRequestException.class, () -> {
+            friendService.rejectFriendRequest(userId, targetId);
+        });
+
+        verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
+        verify(friendMapper, never()).deleteFriendRequest(userId, targetId);
+    }
 }


### PR DESCRIPTION
## FriendController

### `rejectFriendRequest` 메소드 추가

- 친구추가 거절에 대한 요청을 받을 컨트롤러 메소드

## FriendService

### `rejectFriendRequest` 메소드 추가

- 친구추가 거절 요청에 대한 비즈니스 로직을 수행할 메소드

- DB에 등록된 상태가 `친구 요청을 받은 상태(RECEIVED)`와 일치하는 경우에만 요청을 Mapper로 전달

## 테스트

- 친구추가 요청 거절에 대한 로직을 테스트 할 테스트 작성

- 포스트맨을 이용한 테스트