### PR TITLE
[#20] 친구 목록 불러오기 기능 추가

### DIFF
--- a/src/main/java/me/soo/helloworld/controller/FriendController.java
+++ b/src/main/java/me/soo/helloworld/controller/FriendController.java
@@ -56,4 +56,12 @@ public class FriendController {
         List<FriendList> friends = friendService.getFriendList(userId, pageNumber);
         return ResponseEntity.ok(friends);
     }
+
+    @LoginRequired
+    @GetMapping("/friend-requests/from/other-users")
+    public ResponseEntity<List<FriendList>> getFriendRequestList(@CurrentUser String userId,
+                                                          @RequestParam(defaultValue = "1") Integer pageNumber) {
+        List<FriendList> friendRequests = friendService.getFriendRequestList(userId, pageNumber);
+        return ResponseEntity.ok(friendRequests);
+    }
 }

--- a/src/main/java/me/soo/helloworld/controller/FriendController.java
+++ b/src/main/java/me/soo/helloworld/controller/FriendController.java
@@ -3,9 +3,13 @@ package me.soo.helloworld.controller;
 import lombok.RequiredArgsConstructor;
 import me.soo.helloworld.annotation.CurrentUser;
 import me.soo.helloworld.annotation.LoginRequired;
+import me.soo.helloworld.model.friend.FriendList;
 import me.soo.helloworld.service.FriendService;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,5 +47,13 @@ public class FriendController {
     @DeleteMapping("/{targetId}")
     public void unfriendFriend(@CurrentUser String userId, @PathVariable String targetId) {
         friendService.unfriendFriend(userId, targetId);
+    }
+
+    @LoginRequired
+    @GetMapping
+    public ResponseEntity<List<FriendList>> getFriendList(@CurrentUser String userId,
+                                                          @RequestParam(defaultValue = "1") Integer pageNumber) {
+        List<FriendList> friends = friendService.getFriendList(userId, pageNumber);
+        return ResponseEntity.ok(friends);
     }
 }

--- a/src/main/java/me/soo/helloworld/controller/FriendController.java
+++ b/src/main/java/me/soo/helloworld/controller/FriendController.java
@@ -51,9 +51,8 @@ public class FriendController {
 
     @LoginRequired
     @GetMapping
-    public ResponseEntity<List<FriendList>> getFriendList(@CurrentUser String userId,
+    public List<FriendList> getFriendList(@CurrentUser String userId,
                                                           @RequestParam(defaultValue = "1") Integer pageNumber) {
-        List<FriendList> friends = friendService.getFriendList(userId, pageNumber);
-        return ResponseEntity.ok(friends);
+        return friendService.getFriendList(userId, pageNumber);
     }
 }

--- a/src/main/java/me/soo/helloworld/controller/FriendController.java
+++ b/src/main/java/me/soo/helloworld/controller/FriendController.java
@@ -58,10 +58,9 @@ public class FriendController {
     }
 
     @LoginRequired
-    @GetMapping("/friend-requests/from/other-users")
-    public ResponseEntity<List<FriendList>> getFriendRequestList(@CurrentUser String userId,
+    @GetMapping("/friend-requests")
+    public List<FriendList> getFriendRequestList(@CurrentUser String userId,
                                                           @RequestParam(defaultValue = "1") Integer pageNumber) {
-        List<FriendList> friendRequests = friendService.getFriendRequestList(userId, pageNumber);
-        return ResponseEntity.ok(friendRequests);
+        return friendService.getFriendRequestList(userId, pageNumber);
     }
 }

--- a/src/main/java/me/soo/helloworld/mapper/FriendMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/FriendMapper.java
@@ -1,8 +1,12 @@
 package me.soo.helloworld.mapper;
 
 import me.soo.helloworld.enumeration.FriendStatus;
+import me.soo.helloworld.model.friend.FriendList;
+import me.soo.helloworld.model.friend.FriendListRequest;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface FriendMapper {
@@ -16,4 +20,6 @@ public interface FriendMapper {
     public void updateFriendRequest(@Param("userId") String userId,
                                     @Param("targetId") String targetId,
                                     @Param("status") FriendStatus status);
+
+    public List<FriendList> getFriendList(FriendListRequest friendListRequest);
 }

--- a/src/main/java/me/soo/helloworld/model/friend/FriendList.java
+++ b/src/main/java/me/soo/helloworld/model/friend/FriendList.java
@@ -1,0 +1,12 @@
+package me.soo.helloworld.model.friend;
+
+import lombok.Value;
+import me.soo.helloworld.enumeration.FriendStatus;
+
+@Value
+public class FriendList {
+
+    String friendId;
+
+    FriendStatus status;
+}

--- a/src/main/java/me/soo/helloworld/model/friend/FriendListRequest.java
+++ b/src/main/java/me/soo/helloworld/model/friend/FriendListRequest.java
@@ -18,11 +18,14 @@ public class FriendListRequest {
 
     private final FriendStatus status;
 
+    /*
+        Math.max(pageNumber, 1): pageNumber 가 음수로 들어와도 기본값을 1로 설정해서 맨 첫 페이지가 보이도록 설정
+     */
     static public FriendListRequest create(String userId, int pageNumber, FriendStatus status) {
 
         return FriendListRequest.builder()
                                 .userId(userId)
-                                .offset(MAX_PER_PAGE_FRIEND * (Math.max(pageNumber, 1) - 1)) // pageNumber 가 음수로 들어와도 기본값을 1로 설정
+                                .offset(MAX_PER_PAGE_FRIEND * (Math.max(pageNumber, 1) - 1))
                                 .limit(MAX_PER_PAGE_FRIEND)
                                 .status(status)
                                 .build();

--- a/src/main/java/me/soo/helloworld/model/friend/FriendListRequest.java
+++ b/src/main/java/me/soo/helloworld/model/friend/FriendListRequest.java
@@ -1,0 +1,30 @@
+package me.soo.helloworld.model.friend;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import me.soo.helloworld.enumeration.FriendStatus;
+
+import static me.soo.helloworld.util.Pagination.MAX_PER_PAGE_FRIEND;
+
+@Builder
+@AllArgsConstructor
+public class FriendListRequest {
+
+    private final String userId;
+
+    private final int offset;
+
+    private final int limit;
+
+    private final FriendStatus status;
+
+    static public FriendListRequest create(String userId, int pageNumber, FriendStatus status) {
+
+        return FriendListRequest.builder()
+                                .userId(userId)
+                                .offset(MAX_PER_PAGE_FRIEND * (Math.max(pageNumber, 1) - 1)) // pageNumber 가 음수로 들어와도 기본값을 1로 설정
+                                .limit(MAX_PER_PAGE_FRIEND)
+                                .status(status)
+                                .build();
+    }
+}

--- a/src/main/java/me/soo/helloworld/model/friend/FriendListRequest.java
+++ b/src/main/java/me/soo/helloworld/model/friend/FriendListRequest.java
@@ -3,8 +3,7 @@ package me.soo.helloworld.model.friend;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import me.soo.helloworld.enumeration.FriendStatus;
-
-import static me.soo.helloworld.util.Pagination.MAX_PER_PAGE_FRIEND;
+import me.soo.helloworld.util.Pagination;
 
 @Builder
 @AllArgsConstructor
@@ -21,12 +20,12 @@ public class FriendListRequest {
     /*
         Math.max(pageNumber, 1): pageNumber 가 음수로 들어와도 기본값을 1로 설정해서 맨 첫 페이지가 보이도록 설정
      */
-    static public FriendListRequest create(String userId, int pageNumber, FriendStatus status) {
+    static public FriendListRequest create(String userId, int pageNumber, Pagination pagination, FriendStatus status) {
 
         return FriendListRequest.builder()
                                 .userId(userId)
-                                .offset(MAX_PER_PAGE_FRIEND * (Math.max(pageNumber, 1) - 1))
-                                .limit(MAX_PER_PAGE_FRIEND)
+                                .offset(pagination.getMaxPageFriend() * (Math.max(pageNumber, 1) - 1))
+                                .limit(pagination.getMaxPageFriend())
                                 .status(status)
                                 .build();
     }

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -5,8 +5,12 @@ import me.soo.helloworld.enumeration.FriendStatus;
 import me.soo.helloworld.exception.DuplicateFriendRequestException;
 import me.soo.helloworld.exception.InvalidFriendRequestException;
 import me.soo.helloworld.mapper.FriendMapper;
+import me.soo.helloworld.model.friend.FriendList;
+import me.soo.helloworld.model.friend.FriendListRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 import static me.soo.helloworld.enumeration.FriendStatus.*;
 
@@ -59,6 +63,11 @@ public class FriendService {
         FriendStatus friendStatus = getFriendStatus(userId, targetId);
         validateStatus(friendStatus, FRIENDED);
         friendMapper.deleteFriend(userId, targetId);
+    }
+
+    public List<FriendList> getFriendList(String userId, Integer pageNumber) {
+        FriendListRequest request = FriendListRequest.create(userId, pageNumber, FRIENDED);
+        return friendMapper.getFriendList(request);
     }
 
     private void validateStatus(FriendStatus status) {

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -7,6 +7,7 @@ import me.soo.helloworld.exception.InvalidFriendRequestException;
 import me.soo.helloworld.mapper.FriendMapper;
 import me.soo.helloworld.model.friend.FriendList;
 import me.soo.helloworld.model.friend.FriendListRequest;
+import me.soo.helloworld.util.Pagination;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +22,8 @@ public class FriendService {
     private final UserService userService;
 
     private final FriendMapper friendMapper;
+
+    private final Pagination pagination;
 
     public void sendFriendRequest(String userId, String targetId) {
         if (StringUtils.equals(userId, targetId)) {
@@ -66,7 +69,7 @@ public class FriendService {
     }
 
     public List<FriendList> getFriendList(String userId, int pageNumber) {
-        FriendListRequest request = FriendListRequest.create(userId, pageNumber, FRIENDED);
+        FriendListRequest request = FriendListRequest.create(userId, pageNumber, pagination, FRIENDED);
         return friendMapper.getFriendList(request);
     }
 

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -65,7 +65,7 @@ public class FriendService {
         friendMapper.deleteFriend(userId, targetId);
     }
 
-    public List<FriendList> getFriendList(String userId, Integer pageNumber) {
+    public List<FriendList> getFriendList(String userId, int pageNumber) {
         FriendListRequest request = FriendListRequest.create(userId, pageNumber, FRIENDED);
         return friendMapper.getFriendList(request);
     }

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -70,6 +70,11 @@ public class FriendService {
         return friendMapper.getFriendList(request);
     }
 
+    public List<FriendList> getFriendRequestList(String userId, int pageNumber) {
+        FriendListRequest request = FriendListRequest.create(userId, pageNumber, RECEIVED);
+        return friendMapper.getFriendList(request);
+    }
+
     private void validateStatus(FriendStatus status) {
         switch (status) {
             case NOT_YET:

--- a/src/main/java/me/soo/helloworld/util/Pagination.java
+++ b/src/main/java/me/soo/helloworld/util/Pagination.java
@@ -1,6 +1,16 @@
 package me.soo.helloworld.util;
 
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
 public class Pagination {
 
-    public static final int MAX_PER_PAGE_FRIEND = 30;
+    private final int maxPageFriend;
+
+    public Pagination(@Value("${friend.max.page:30}") int maxPageFriend) {
+        this.maxPageFriend = maxPageFriend;
+    }
 }

--- a/src/main/java/me/soo/helloworld/util/Pagination.java
+++ b/src/main/java/me/soo/helloworld/util/Pagination.java
@@ -1,0 +1,6 @@
+package me.soo.helloworld.util;
+
+public class Pagination {
+
+    public static final int MAX_PER_PAGE_FRIEND = 30;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # DB 커넥션을 위한 DB 정보 저장(코드의 중복/실수 방지)
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/helloworld?allowMultiQueries=true
-spring.datasource.username=helloworld
+spring.datasource.url=jdbc:mysql://localhost:3306/hw?allowMultiQueries=true
+spring.datasource.username=hw_repl
 spring.datasource.password=helloworld
 
 # 프로필 사진 업로드 구현을 위한 MultiPart Properties 설정
@@ -32,3 +32,6 @@ spring.mail.username=testemailserver907@gmail.com
 spring.mail.password=!xp%tm#xm@1
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+# Pagination 외부 주입 값 - default 는 30으로 설정되어 있음
+max.page.friend=50

--- a/src/main/resources/mappers/FriendMapper.xml
+++ b/src/main/resources/mappers/FriendMapper.xml
@@ -29,4 +29,13 @@
                 OR (userId = #{targetId} AND friendId = #{userId})
     </update>
 
+    <select id="getFriendList" parameterType="me.soo.helloworld.model.friend.FriendListRequest"
+            resultType="me.soo.helloworld.model.friend.FriendList">
+
+        SELECT friendId, status FROM friends
+            WHERE userId = #{userId} AND status = #{status}
+        ORDER BY id DESC
+        LIMIT #{offset}, #{limit}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 📝 페이징 적용
-  친구 수가 엄청나게 많은 사용자가 있다고 가정하면 `모든 친구를 한 번에 불러오는 것은 비효율적`이기도 하고, 데이터를 불러올 때 `로딩에도 영향`을 미친다고 생각했고 DB에 조건에 맞는 데이터가 많을 수록 페이징은 필수라고 생각해서 적용했습니다.

## 📖 Model 관련

### 📑  FriedListRequest

- 친구목록 불러오기에 필요한 값들을 담아서 DB로 전달할 객체를 생성하기 위한 클래스

- pageNumber 가 `음수로 들어와도 기본값을 1로 설정`해서 맨 첫 페이지가 보이도록 설정

### 📑 FriendList

- DB로 부터 가져온 `결과 값을 담을 객체`를 생성할 클래스(친구 ID와 친구 상태를 인스턴스 변수로 가지고 있음)

- immutable 객체 상태로 직렬화가 가능하게 만드는 Lombok `@Value`  어노테이션 활용

## 📝 상수 관련

### 📑 Pagination

- 페이징 시 항목 별로 최대 페이지 값을 담아두기 위한 클래스 생성

## 📝 컨트롤러 계층 관련

### 📑 FriendController: getFriendList 메소드 추가

- 현재 사용자의 친구 목록을 불러오기 위한 요청을 매핑할 메소드

- 첫 화면을 표시하기 위한 pageNumber `기본값` 설정

- 받아온 친구목록을 `ResponseEntity`를 활용해 본문에 담아서 화면에 반환

## 📝 서비스 계층 관련

### 📑 FriendService: getFriendList 메소드 추가

- 들어온 요청을 바탕으로 `FriendListRequest` 객체를 생성해 Mapper에 전달

- 반환된 값은 Controller에 전달

## 📝 매퍼 계층 관련

### 📑 FriendMapper: getFriendList 메소드 추가

- DB에서 친구목록을 불러오기 위한 메소드

### 📑 FriemdMapper.xml

- 위의 로직을 처리 할 쿼리문 추가