### PR TITLE
[#24] 사용자 차단 해제 기능 구현

### DIFF
--- a/src/main/java/me/soo/helloworld/controller/BlockUserController.java
+++ b/src/main/java/me/soo/helloworld/controller/BlockUserController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import me.soo.helloworld.annotation.CurrentUser;
 import me.soo.helloworld.annotation.LoginRequired;
 import me.soo.helloworld.service.BlockUserService;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +17,11 @@ public class BlockUserController {
     @PostMapping("/{targetId}")
     public void blockUser(@CurrentUser String userId, @PathVariable String targetId) {
         blockUserService.blockUser(userId, targetId);
+    }
+
+    @LoginRequired
+    @DeleteMapping ("/{targetId}")
+    public void unBlockUser(@CurrentUser String userId, @PathVariable String targetId) {
+        blockUserService.unblockUser(userId, targetId);
     }
 }

--- a/src/main/java/me/soo/helloworld/mapper/BlockUserMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/BlockUserMapper.java
@@ -5,7 +5,9 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface BlockUserMapper {
 
-    public void blockUser(String userId, String targetId);
+    public void insertBlockUser(String userId, String targetId);
 
     public boolean isUserBlocked(String userId, String targetId);
+
+    public void deleteBlockUser(String userId, String targetId);
 }

--- a/src/main/java/me/soo/helloworld/service/BlockUserService.java
+++ b/src/main/java/me/soo/helloworld/service/BlockUserService.java
@@ -2,6 +2,7 @@ package me.soo.helloworld.service;
 
 import lombok.RequiredArgsConstructor;
 import me.soo.helloworld.exception.DuplicateRequestException;
+import me.soo.helloworld.exception.InvalidRequestException;
 import me.soo.helloworld.mapper.BlockUserMapper;
 import me.soo.helloworld.mapper.FriendMapper;
 import me.soo.helloworld.util.TargetValidator;
@@ -30,16 +31,24 @@ public class BlockUserService {
             case FRIEND_REQUESTED:
             case FRIEND_REQUEST_RECEIVED:
                 friendMapper.deleteFriend(userId, targetId);
-                blockUserMapper.blockUser(userId, targetId);
+                blockUserMapper.insertBlockUser(userId, targetId);
                 break;
             case NONE:
             default:
-                blockUserMapper.blockUser(userId, targetId);
+                blockUserMapper.insertBlockUser(userId, targetId);
                 break;
         }
     }
 
     public boolean isUserBlocked(String userId, String targetId) {
         return blockUserMapper.isUserBlocked(userId, targetId);
+    }
+
+    public void unblockUser(String userId, String targetId) {
+        if (!isUserBlocked(userId, targetId)) {
+            throw new InvalidRequestException("차단되어 있지 않은 사용자를 차단해제 할 수 없습니다. 다시 한 번 확인해주세요.");
+        }
+
+        blockUserMapper.deleteBlockUser(userId, targetId);
     }
 }

--- a/src/main/resources/mappers/BlockUserMapper.xml
+++ b/src/main/resources/mappers/BlockUserMapper.xml
@@ -4,9 +4,7 @@
 <mapper namespace="me.soo.helloworld.mapper.BlockUserMapper">
 
     <insert id="insertBlockUser" parameterType="String">
-
-        INSERT INTO block (userId, blockId)
-            VALUES (#{userId}, #{targetId})
+        INSERT INTO block (userId, blockId) VALUES (#{userId}, #{targetId})
     </insert>
 
     <select id="isUserBlocked" parameterType="String" resultType="boolean">
@@ -14,7 +12,6 @@
     </select>
 
     <delete id="deleteBlockUser" parameterType="String">
-
         DELETE FROM block WHERE userId = #{userId} AND blockId = #{targetId}
     </delete>
 </mapper>

--- a/src/main/resources/mappers/BlockUserMapper.xml
+++ b/src/main/resources/mappers/BlockUserMapper.xml
@@ -3,7 +3,7 @@
 
 <mapper namespace="me.soo.helloworld.mapper.BlockUserMapper">
 
-    <insert id="blockUser" parameterType="String">
+    <insert id="insertBlockUser" parameterType="String">
 
         INSERT INTO block (userId, blockId)
             VALUES (#{userId}, #{targetId})
@@ -12,4 +12,9 @@
     <select id="isUserBlocked" parameterType="String" resultType="boolean">
         SELECT EXISTS (SELECT blockId FROM block WHERE userId = #{userId} AND blockId = #{targetId})
     </select>
+
+    <delete id="deleteBlockUser" parameterType="String">
+
+        DELETE FROM block WHERE userId = #{userId} AND blockId = #{targetId}
+    </delete>
 </mapper>

--- a/src/test/java/me/soo/helloworld/service/BlockUserServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/BlockUserServiceTest.java
@@ -43,7 +43,7 @@ public class BlockUserServiceTest {
 
         verify(userService, never()).isUserIdExist(targetId);
         verify(friendMapper, never()).deleteFriend(userId, targetId);
-        verify(blockUserMapper, never()).blockUser(userId, targetId);
+        verify(blockUserMapper, never()).insertBlockUser(userId, targetId);
     }
 
     @Test
@@ -57,7 +57,7 @@ public class BlockUserServiceTest {
 
         verify(userService, times(1)).isUserIdExist(targetId);
         verify(friendMapper, never()).deleteFriend(userId, targetId);
-        verify(blockUserMapper, never()).blockUser(userId, targetId);
+        verify(blockUserMapper, never()).insertBlockUser(userId, targetId);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class BlockUserServiceTest {
         verify(userService, times(1)).isUserIdExist(targetId);
         verify(blockUserMapper, times(1)).isUserBlocked(userId, targetId);
         verify(friendMapper, never()).deleteFriend(userId, targetId);
-        verify(blockUserMapper, never()).blockUser(userId, targetId);
+        verify(blockUserMapper, never()).insertBlockUser(userId, targetId);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class BlockUserServiceTest {
         verify(userService, times(1)).isUserIdExist(targetId);
         verify(blockUserMapper, times(1)).isUserBlocked(userId, targetId);
         verify(friendMapper, times(1)).deleteFriend(userId, targetId);
-        verify(blockUserMapper, times(1)).blockUser(userId, targetId);
+        verify(blockUserMapper, times(1)).insertBlockUser(userId, targetId);
     }
 
     @Test
@@ -103,7 +103,7 @@ public class BlockUserServiceTest {
         verify(userService, times(1)).isUserIdExist(targetId);
         verify(blockUserMapper, times(1)).isUserBlocked(userId, targetId);
         verify(friendMapper, times(1)).deleteFriend(userId, targetId);
-        verify(blockUserMapper, times(1)).blockUser(userId, targetId);
+        verify(blockUserMapper, times(1)).insertBlockUser(userId, targetId);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class BlockUserServiceTest {
         verify(userService, times(1)).isUserIdExist(targetId);
         verify(blockUserMapper, times(1)).isUserBlocked(userId, targetId);
         verify(friendMapper, times(1)).deleteFriend(userId, targetId);
-        verify(blockUserMapper, times(1)).blockUser(userId, targetId);
+        verify(blockUserMapper, times(1)).insertBlockUser(userId, targetId);
     }
 
     @Test
@@ -133,6 +133,30 @@ public class BlockUserServiceTest {
         verify(userService, times(1)).isUserIdExist(targetId);
         verify(blockUserMapper, times(1)).isUserBlocked(userId, targetId);
         verify(friendMapper, never()).deleteFriend(userId, targetId);
-        verify(blockUserMapper, times(1)).blockUser(userId, targetId);
+        verify(blockUserMapper, times(1)).insertBlockUser(userId, targetId);
+    }
+
+    @Test
+    @DisplayName("이미 차단되어 있지 않은 사용자의 경우 차단해제를 시도하면 InvalidRequestException 이 발생하며 차단 해제에 실패합니다.")
+    public void unBlockUserFailToNotBlockedTarget() {
+        when(blockUserMapper.isUserBlocked(userId, targetId)).thenReturn(false);
+
+        assertThrows(InvalidRequestException.class, () -> {
+            blockUserService.unblockUser(userId, targetId);
+        });
+
+        verify(blockUserMapper, times(1)).isUserBlocked(userId, targetId);
+        verify(blockUserMapper, never()).deleteBlockUser(userId, targetId);
+    }
+
+    @Test
+    @DisplayName("이미 차단되어 있는 사용자의 경우 차단 해제에 성공합니다.")
+    public void unBlockUserSuccessToBlockedTarget() {
+        when(blockUserMapper.isUserBlocked(userId, targetId)).thenReturn(true);
+
+        blockUserService.unblockUser(userId, targetId);
+
+        verify(blockUserMapper, times(1)).isUserBlocked(userId, targetId);
+        verify(blockUserMapper, times(1)).deleteBlockUser(userId, targetId);
     }
 }

--- a/src/test/java/me/soo/helloworld/service/login/LoginServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/login/LoginServiceTest.java
@@ -1,6 +1,6 @@
 package me.soo.helloworld.service.login;
 
-import com.sun.jdi.request.DuplicateRequestException;
+import me.soo.helloworld.exception.DuplicateRequestException;
 import me.soo.helloworld.model.user.UserLoginRequest;
 import me.soo.helloworld.model.user.User;
 import me.soo.helloworld.service.SessionLoginService;


### PR DESCRIPTION
## 📖 Controller 계층 관련

### 📑  BlockUserController

- 사용자 차단 해제 요청을 받을 `unblockUser` 메소드 추가

## 📖 Service 계층 관련

### 📑 BlockUserService

- 사용자 차단 해제에 요청에 대한 비즈니스 로직을 처리 할 `unblockUser`  메소드 추가

## 📖 Mapper 계층 관련

### 📑 BlockUserMapper

- DB에 차단 해제 내역을 반영 할 `deleteBlockUser` 메소드 추가

- DB 관련 행동임을 더 잘 나타내기 위해서 `blockUser -> insertBlockUser`로 메소드 이름 변경

## 📖 테스트 관련

- 사용자 차단 해제에 관련된 단위 테스트 작성

- 포스트맨을 활용해 전체적인 테스트