### PR TITLE
[#26] 요청에 대한 알림 추가 기능 구현

### DIFF
--- a/src/main/java/me/soo/helloworld/config/MyBatisConfig.java
+++ b/src/main/java/me/soo/helloworld/config/MyBatisConfig.java
@@ -1,5 +1,6 @@
 package me.soo.helloworld.config;
 
+import me.soo.helloworld.enumeration.AlarmTypes;
 import me.soo.helloworld.enumeration.FriendStatus;
 import me.soo.helloworld.enumeration.LanguageLevel;
 import me.soo.helloworld.enumeration.LanguageStatus;
@@ -28,7 +29,7 @@ public class MyBatisConfig {
         sessionFactory.setMapperLocations(resolver.getResources("/mappers/*.xml"));
 
         sessionFactory.setTypeHandlers(new LanguageLevel.TypeHandler(), new LanguageStatus.TypeHandler(),
-                                        new FriendStatus.TypeHandler());
+                                        new FriendStatus.TypeHandler(), new AlarmTypes.TypeHandler());
 
         return sessionFactory.getObject();
     }

--- a/src/main/java/me/soo/helloworld/controller/BlockUserController.java
+++ b/src/main/java/me/soo/helloworld/controller/BlockUserController.java
@@ -6,6 +6,8 @@ import me.soo.helloworld.annotation.LoginRequired;
 import me.soo.helloworld.service.BlockUserService;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/block-users")
@@ -23,5 +25,12 @@ public class BlockUserController {
     @DeleteMapping ("/{targetId}")
     public void unBlockUser(@CurrentUser String userId, @PathVariable String targetId) {
         blockUserService.unblockUser(userId, targetId);
+    }
+
+    @LoginRequired
+    @GetMapping
+    public List<String> getBlockUserList(@CurrentUser String userId,
+                                         @RequestParam(defaultValue = "1") Integer pageNumber) {
+        return blockUserService.getBlockUserList(userId, pageNumber);
     }
 }

--- a/src/main/java/me/soo/helloworld/enumeration/AlarmTypes.java
+++ b/src/main/java/me/soo/helloworld/enumeration/AlarmTypes.java
@@ -1,0 +1,24 @@
+package me.soo.helloworld.enumeration;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import me.soo.helloworld.util.handler.EnumCategoryTypeHandler;
+import org.apache.ibatis.type.MappedTypes;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlarmTypes implements EnumCategory {
+
+    FRIEND_REQUEST_RECEIVED(1),
+    FRIEND_REQUEST_ACCEPTED(2);
+
+    private final int category;
+
+    @MappedTypes(AlarmTypes.class)
+    public static class TypeHandler extends EnumCategoryTypeHandler<AlarmTypes> {
+
+        public TypeHandler() {
+            super(AlarmTypes.class);
+        }
+    }
+}

--- a/src/main/java/me/soo/helloworld/mapper/AlarmMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/AlarmMapper.java
@@ -1,0 +1,10 @@
+package me.soo.helloworld.mapper;
+
+import me.soo.helloworld.model.alarm.Alarm;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AlarmMapper {
+
+    public void insertAlarm(Alarm alarm);
+}

--- a/src/main/java/me/soo/helloworld/mapper/BlockUserMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/BlockUserMapper.java
@@ -1,6 +1,9 @@
 package me.soo.helloworld.mapper;
 
+import me.soo.helloworld.model.blockuser.BlockUserListRequest;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 @Mapper
 public interface BlockUserMapper {
@@ -10,4 +13,6 @@ public interface BlockUserMapper {
     public boolean isUserBlocked(String userId, String targetId);
 
     public void deleteBlockUser(String userId, String targetId);
+
+    public List<String> getBlockUserList(BlockUserListRequest request);
 }

--- a/src/main/java/me/soo/helloworld/model/alarm/Alarm.java
+++ b/src/main/java/me/soo/helloworld/model/alarm/Alarm.java
@@ -1,0 +1,25 @@
+package me.soo.helloworld.model.alarm;
+
+import lombok.Builder;
+import lombok.Getter;
+import me.soo.helloworld.enumeration.AlarmTypes;
+
+@Getter
+@Builder
+public class Alarm {
+
+    private final String to;
+
+    private final String from;
+
+    private final AlarmTypes type;
+
+    public static Alarm create(String userId, String targetId, AlarmTypes type) {
+
+        return Alarm.builder()
+                    .from(userId)
+                    .to(targetId)
+                    .type(type)
+                    .build();
+    }
+}

--- a/src/main/java/me/soo/helloworld/model/alarm/Alarm.java
+++ b/src/main/java/me/soo/helloworld/model/alarm/Alarm.java
@@ -14,11 +14,11 @@ public class Alarm {
 
     private final AlarmTypes type;
 
-    public static Alarm create(String userId, String targetId, AlarmTypes type) {
+    public static Alarm create(String to, String from, AlarmTypes type) {
 
         return Alarm.builder()
-                    .from(userId)
-                    .to(targetId)
+                    .to(to)
+                    .from(from)
                     .type(type)
                     .build();
     }

--- a/src/main/java/me/soo/helloworld/model/blockuser/BlockUserListRequest.java
+++ b/src/main/java/me/soo/helloworld/model/blockuser/BlockUserListRequest.java
@@ -1,0 +1,25 @@
+package me.soo.helloworld.model.blockuser;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import me.soo.helloworld.util.Pagination;
+
+@Builder
+@AllArgsConstructor
+public class BlockUserListRequest {
+
+    private final String userId;
+
+    private final int offset;
+
+    private final int limit;
+
+    static public BlockUserListRequest create(String userId, int pageNumber, Pagination pagination) {
+
+        return BlockUserListRequest.builder()
+                                    .userId(userId)
+                                    .offset(pagination.getMaxPageBlockUser() * (Math.max(pageNumber, 1) - 1))
+                                    .limit(pagination.getMaxPageBlockUser())
+                                    .build();
+    }
+}

--- a/src/main/java/me/soo/helloworld/service/AlarmService.java
+++ b/src/main/java/me/soo/helloworld/service/AlarmService.java
@@ -1,0 +1,19 @@
+package me.soo.helloworld.service;
+
+import lombok.RequiredArgsConstructor;
+import me.soo.helloworld.enumeration.AlarmTypes;
+import me.soo.helloworld.mapper.AlarmMapper;
+import me.soo.helloworld.model.alarm.Alarm;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmService {
+
+    private final AlarmMapper alarmMapper;
+
+    public void addAlarm(String to, String from, AlarmTypes type) {
+        Alarm alarm = Alarm.create(to, from, type);
+        alarmMapper.insertAlarm(alarm);
+    }
+}

--- a/src/main/java/me/soo/helloworld/service/BlockUserService.java
+++ b/src/main/java/me/soo/helloworld/service/BlockUserService.java
@@ -5,8 +5,13 @@ import me.soo.helloworld.exception.DuplicateRequestException;
 import me.soo.helloworld.exception.InvalidRequestException;
 import me.soo.helloworld.mapper.BlockUserMapper;
 import me.soo.helloworld.mapper.FriendMapper;
+import me.soo.helloworld.model.blockuser.BlockUserListRequest;
+import me.soo.helloworld.util.Pagination;
 import me.soo.helloworld.util.TargetValidator;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +22,8 @@ public class BlockUserService {
     private final FriendMapper friendMapper;
 
     private final BlockUserMapper blockUserMapper;
+
+    private final Pagination pagination;
 
     public void blockUser(String userId, String targetId) {
         TargetValidator.targetNotSelf(userId, targetId);
@@ -50,5 +57,11 @@ public class BlockUserService {
         }
 
         blockUserMapper.deleteBlockUser(userId, targetId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getBlockUserList(String userId, int pageNumber) {
+        BlockUserListRequest request = BlockUserListRequest.create(userId, pageNumber, pagination);
+        return blockUserMapper.getBlockUserList(request);
     }
 }

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -1,6 +1,7 @@
 package me.soo.helloworld.service;
 
 import lombok.RequiredArgsConstructor;
+import me.soo.helloworld.enumeration.AlarmTypes;
 import me.soo.helloworld.enumeration.FriendStatus;
 import me.soo.helloworld.exception.DuplicateRequestException;
 import me.soo.helloworld.exception.InvalidRequestException;
@@ -28,6 +29,8 @@ public class FriendService {
 
     private final Pagination pagination;
 
+    private final AlarmService alarmService;
+
     public void sendFriendRequest(String userId, String targetId) {
         TargetValidator.targetNotSelf(userId, targetId);
         TargetValidator.targetExistence(userService.isUserIdExist(targetId));
@@ -40,6 +43,7 @@ public class FriendService {
         validateFriendStatusDetail(status);
 
         friendMapper.sendFriendRequest(userId, targetId);
+        alarmService.addAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     public FriendStatus getFriendStatus(String userId, String targetId) {
@@ -56,6 +60,7 @@ public class FriendService {
         FriendStatus status = getFriendStatus(userId, targetId);
         validateFriendStatus(status, FRIEND_REQUEST_RECEIVED);
         friendMapper.updateFriendRequest(userId, targetId, FRIEND);
+        alarmService.addAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_ACCEPTED);
     }
 
     public void rejectFriendRequest(String userId, String targetId) {

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -31,6 +31,7 @@ public class FriendService {
 
     private final AlarmService alarmService;
 
+    @Transactional
     public void sendFriendRequest(String userId, String targetId) {
         TargetValidator.targetNotSelf(userId, targetId);
         TargetValidator.targetExistence(userService.isUserIdExist(targetId));
@@ -56,6 +57,7 @@ public class FriendService {
         friendMapper.deleteFriend(userId, targetId);
     }
 
+    @Transactional
     public void acceptFriendRequest(String userId, String targetId) {
         FriendStatus status = getFriendStatus(userId, targetId);
         validateFriendStatus(status, FRIEND_REQUEST_RECEIVED);

--- a/src/main/java/me/soo/helloworld/util/Pagination.java
+++ b/src/main/java/me/soo/helloworld/util/Pagination.java
@@ -10,7 +10,11 @@ public class Pagination {
 
     private final int maxPageFriend;
 
-    public Pagination(@Value("${friend.max.page:30}") int maxPageFriend) {
+    private final int maxPageBlockUser;
+
+    public Pagination(@Value("${friend.max.page:30}") int maxPageFriend,
+                      @Value("${block_user.max.page:30}") int maxPageBlockUser) {
         this.maxPageFriend = maxPageFriend;
+        this.maxPageBlockUser = maxPageBlockUser;
     }
 }

--- a/src/main/resources/mappers/AlarmMapper.xml
+++ b/src/main/resources/mappers/AlarmMapper.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="me.soo.helloworld.mapper.AlarmMapper">
+
+    <insert id="insertAlarm" parameterType="me.soo.helloworld.model.alarm.Alarm">
+        INSERT INTO alarms (alarmTo, alarmFrom, type) VALUES (#{to}, #{from}, #{type})
+    </insert>
+</mapper>

--- a/src/main/resources/mappers/BlockUserMapper.xml
+++ b/src/main/resources/mappers/BlockUserMapper.xml
@@ -4,9 +4,7 @@
 <mapper namespace="me.soo.helloworld.mapper.BlockUserMapper">
 
     <insert id="insertBlockUser" parameterType="String">
-
-        INSERT INTO block (userId, blockId)
-            VALUES (#{userId}, #{targetId})
+        INSERT INTO block (userId, blockId) VALUES (#{userId}, #{targetId})
     </insert>
 
     <select id="isUserBlocked" parameterType="String" resultType="boolean">
@@ -14,7 +12,13 @@
     </select>
 
     <delete id="deleteBlockUser" parameterType="String">
-
         DELETE FROM block WHERE userId = #{userId} AND blockId = #{targetId}
     </delete>
+
+    <select id="getBlockUserList" parameterType="me.soo.helloworld.model.blockuser.BlockUserListRequest" resultType="String">
+
+        SELECT blockId FROM block WHERE userId = #{userId}
+        ORDER BY id DESC
+        LIMIT #{offset}, #{limit}
+    </select>
 </mapper>

--- a/src/main/resources/sql/alarms.sql
+++ b/src/main/resources/sql/alarms.sql
@@ -1,0 +1,10 @@
+create table alarms
+(
+    id        bigint auto_increment
+        primary key,
+    alarmTo   varchar(20)                               not null,
+    alarmFrom varchar(20)                               not null,
+    type      tinyint                                   not null,
+    hasRead   enum ('Y', 'N') default 'N'               not null,
+    createdAt timestamp       default CURRENT_TIMESTAMP not null
+);

--- a/src/main/resources/sql/alarms.sql
+++ b/src/main/resources/sql/alarms.sql
@@ -8,3 +8,6 @@ create table alarms
     hasRead   enum ('Y', 'N') default 'N'               not null,
     createdAt timestamp       default CURRENT_TIMESTAMP not null
 );
+
+create index alarms_alarmTo_alarmFrom_index
+    on alarms (alarmTo, alarmFrom);


### PR DESCRIPTION
## 📖 Enum 관련

### 📑  `AlarmTypes` 클래스 추가

- `Alarm 관련 타입 상수`를 담을 클래스

- DB에 저장 시 정수로, DB에서 꺼낼 때는 정식 명칭을 가진 상수로의 `자동변환`을 위해 `TypeHandler` 구현 및 MyBatisConfig에 추가

## 📖 Mapper 계층 관련

### 📑 `AlarmMapper` 인터페이스 추가

- 알람 추가 기능에 대한 로직 처리 후 이를 DB에 반영하기 위한 `insertAlarm` 메소드 추가

### 📑 `AlarmMapper.xml` 추가

- 위의 사항을 처리할 쿼리문 작성

## 📖 Service 계층 관련

### 📑 `AlarmService` 클래스 추가

- 알람 추가 기능 요청에 대한 비즈니스 로직을 처리할 `addAlarm` 메소드 추가

- 알람 추가 요청을 받으면 보내는 대상과 받을 대상 그리고 알람 타입을 매핑해서 `Alarm 클래스의 인스턴스 생성` 후 Mapper로 넘김

### 📑 FriendService

- `AlarmService 주입` 및 알람 추가가 필요한 메소드`(친구추가 요청, 친구수락 요청)`들에 `addAlarm코드 추가`

## 📖 테스트 관련

- 전체적인 내용을 포스트맨을 활용해 테스트