### PR TITLE
[#28] 사용자의 개별 알람 읽기 기능 구현

### DIFF
--- a/src/main/java/me/soo/helloworld/controller/AlarmController.java
+++ b/src/main/java/me/soo/helloworld/controller/AlarmController.java
@@ -25,7 +25,7 @@ public class AlarmController {
 
     @LoginRequired
     @GetMapping("/{alarm-id}")
-    public Alarm readAlarm(@CurrentUser String userId, @PathVariable("alarm-id") Integer alarmId) {
-        return alarmService.readAlarm(alarmId, userId);
+    public Alarm getAlarm(@CurrentUser String userId, @PathVariable("alarm-id") Integer alarmId) {
+        return alarmService.getAlarm(alarmId, userId);
     }
 }

--- a/src/main/java/me/soo/helloworld/controller/AlarmController.java
+++ b/src/main/java/me/soo/helloworld/controller/AlarmController.java
@@ -5,10 +5,7 @@ import me.soo.helloworld.annotation.CurrentUser;
 import me.soo.helloworld.annotation.LoginRequired;
 import me.soo.helloworld.model.alarm.Alarm;
 import me.soo.helloworld.service.AlarmService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -24,5 +21,11 @@ public class AlarmController {
     public List<Alarm> getAlarmList(@CurrentUser String userId,
                                     @RequestParam(defaultValue = "1") Integer pageNumber) {
         return alarmService.getAlarmList(userId, pageNumber);
+    }
+
+    @LoginRequired
+    @GetMapping("/{alarm-id}")
+    public Alarm readAlarm(@CurrentUser String userId, @PathVariable("alarm-id") Integer alarmId) {
+        return alarmService.readAlarm(alarmId, userId);
     }
 }

--- a/src/main/java/me/soo/helloworld/exception/NoSuchAlarmException.java
+++ b/src/main/java/me/soo/helloworld/exception/NoSuchAlarmException.java
@@ -1,0 +1,12 @@
+package me.soo.helloworld.exception;
+
+public class NoSuchAlarmException extends RuntimeException {
+
+    public NoSuchAlarmException(String message) {
+        super(message);
+    }
+
+    public NoSuchAlarmException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/me/soo/helloworld/mapper/AlarmMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/AlarmMapper.java
@@ -4,8 +4,10 @@ import me.soo.helloworld.model.alarm.Alarm;
 import me.soo.helloworld.model.alarm.AlarmData;
 import me.soo.helloworld.model.alarm.AlarmListRequest;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface AlarmMapper {
@@ -13,4 +15,8 @@ public interface AlarmMapper {
     public void insertAlarm(AlarmData alarm);
 
     List<Alarm> getAlarmList(AlarmListRequest request);
+
+    Optional<Alarm> getAlarm(@Param("alarmId") int alarmId, @Param("userId") String userId);
+
+    public void updateToRead(@Param("alarmId") int alarmId, @Param("userId") String userId);
 }

--- a/src/main/java/me/soo/helloworld/mapper/AlarmMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/AlarmMapper.java
@@ -14,9 +14,11 @@ public interface AlarmMapper {
 
     public void insertAlarm(AlarmData alarm);
 
-    List<Alarm> getAlarmList(AlarmListRequest request);
+    public List<Alarm> getAlarmList(AlarmListRequest request);
 
-    Optional<Alarm> getAlarm(@Param("alarmId") int alarmId, @Param("userId") String userId);
+    public Alarm getAlarm(@Param("alarmId") int alarmId, @Param("userId") String userId);
+
+    public Optional<String> getHasReadStatus(@Param("alarmId") int alarmId, @Param("userId") String userId);
 
     public void updateToRead(@Param("alarmId") int alarmId, @Param("userId") String userId);
 }

--- a/src/main/java/me/soo/helloworld/service/AlarmService.java
+++ b/src/main/java/me/soo/helloworld/service/AlarmService.java
@@ -2,6 +2,8 @@ package me.soo.helloworld.service;
 
 import lombok.RequiredArgsConstructor;
 import me.soo.helloworld.enumeration.AlarmTypes;
+import me.soo.helloworld.exception.InvalidRequestException;
+import me.soo.helloworld.exception.NoSuchAlarmException;
 import me.soo.helloworld.mapper.AlarmMapper;
 import me.soo.helloworld.model.alarm.Alarm;
 import me.soo.helloworld.model.alarm.AlarmData;
@@ -27,6 +29,17 @@ public class AlarmService {
     public List<Alarm> getAlarmList(String userId, int pageNumber) {
         AlarmListRequest request = AlarmListRequest.create(userId, pageNumber, pagination);
         return alarmMapper.getAlarmList(request);
+    }
+
+    public Alarm readAlarm(int alarmId, String userId) {
+        Alarm alarm = alarmMapper.getAlarm(alarmId, userId)
+                                    .orElseThrow(() -> new NoSuchAlarmException("존재하지 않는 알람에 대한 정보는 읽어올 수 없습니다. 다시 한 번 확인해주세요."));
+
+        if (alarm.getHasRead().equals("N")) {
+            alarmMapper.updateToRead(alarmId, userId);
+        }
+
+        return alarm;
     }
 
 }

--- a/src/main/java/me/soo/helloworld/service/AlarmService.java
+++ b/src/main/java/me/soo/helloworld/service/AlarmService.java
@@ -41,7 +41,7 @@ public class AlarmService {
         String hasRead = alarmMapper.getHasReadStatus(alarmId, userId)
                 .orElseThrow(() -> new NoSuchAlarmException("존재하지 않는 알람에 대한 정보는 읽어올 수 없습니다."));
 
-        if (hasRead.equals("N")) {
+        if ("N".equals(hasRead)) {
             alarmMapper.updateToRead(alarmId, userId);
         }
     }

--- a/src/main/java/me/soo/helloworld/util/handler/ControllerExceptionHandler.java
+++ b/src/main/java/me/soo/helloworld/util/handler/ControllerExceptionHandler.java
@@ -54,7 +54,7 @@ public class ControllerExceptionHandler {
     }
 
     @ExceptionHandler(InvalidRequestException.class)
-    public ResponseEntity<ExceptionResponse> InvalidRequestException(final InvalidRequestException ex) {
+    public ResponseEntity<ExceptionResponse> invalidRequestException(final InvalidRequestException ex) {
         log.error(ex.getMessage(), ex);
         ExceptionResponse response = new ExceptionResponse("유효하지 않는 요청입니다.", ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
@@ -68,9 +68,16 @@ public class ControllerExceptionHandler {
     }
 
     @ExceptionHandler(DuplicateRequestException.class)
-    public ResponseEntity<ExceptionResponse> DuplicateRequestException(final DuplicateRequestException ex) {
+    public ResponseEntity<ExceptionResponse> duplicateRequestException(final DuplicateRequestException ex) {
         log.error(ex.getMessage(), ex);
         ExceptionResponse response = new ExceptionResponse("중복된 요청입니다.", ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NoSuchAlarmException.class)
+    public ResponseEntity<ExceptionResponse> noSuchAlarmException (final NoSuchAlarmException ex) {
+        log.error(ex.getMessage(), ex);
+        ExceptionResponse response = new ExceptionResponse("존재하지 않는 리소스입니다.", ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/resources/mappers/AlarmMapper.xml
+++ b/src/main/resources/mappers/AlarmMapper.xml
@@ -27,4 +27,8 @@
         UPDATE alarms SET hasRead = 'Y'
         WHERE id = #{alarmId} AND alarmTo = #{userId}
     </update>
+
+    <select id="getHasReadStatus" parameterType="map" resultType="String">
+        SELECT hasRead FROM alarms WHERE id = #{alarmId} AND alarmTo = #{userId}
+    </select>
 </mapper>

--- a/src/main/resources/mappers/AlarmMapper.xml
+++ b/src/main/resources/mappers/AlarmMapper.xml
@@ -15,4 +15,16 @@
         ORDER BY id DESC
         LIMIT #{offset}, #{limit}
     </select>
+
+    <select id="getAlarm" parameterType="map" resultType="me.soo.helloworld.model.alarm.Alarm">
+
+        SELECT id, alarmTo, alarmFrom, type, hasRead, createdAt FROM alarms
+        WHERE id = #{alarmId} AND alarmTo = #{userId}
+    </select>
+
+    <update id="updateToRead">
+
+        UPDATE alarms SET hasRead = 'Y'
+        WHERE id = #{alarmId} AND alarmTo = #{userId}
+    </update>
 </mapper>

--- a/src/test/java/me/soo/helloworld/service/AlarmServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/AlarmServiceTest.java
@@ -1,11 +1,7 @@
 package me.soo.helloworld.service;
 
-import me.soo.helloworld.enumeration.AlarmTypes;
-import me.soo.helloworld.exception.InvalidRequestException;
 import me.soo.helloworld.exception.NoSuchAlarmException;
 import me.soo.helloworld.mapper.AlarmMapper;
-import me.soo.helloworld.model.alarm.Alarm;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,7 +9,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.sql.Date;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -25,15 +20,7 @@ public class AlarmServiceTest {
 
     private final String to = "Soo";
 
-    private final String from = "Not Soo";
-
     private final int alarmId = 1;
-
-    private final Date createdDate = Date.valueOf("2021-03-15");
-
-    Alarm readAlarm;
-
-    Alarm unreadAlarm;
 
     @InjectMocks
     AlarmService alarmService;
@@ -41,49 +28,46 @@ public class AlarmServiceTest {
     @Mock
     AlarmMapper alarmMapper;
 
-    @BeforeEach
-    public void createUnreadAlarm() {
-        readAlarm = new Alarm(alarmId, to, from, AlarmTypes.FRIEND_REQUEST_RECEIVED, "Y", createdDate);
-    }
-
-    @BeforeEach
-    public void createReadAlarm() {
-        unreadAlarm = new Alarm(alarmId, to, from, AlarmTypes.FRIEND_REQUEST_RECEIVED, "N", createdDate);
-    }
-
     @Test
-    @DisplayName("해당 알람이 존재하고 기존에 읽지 않았을 경우 읽은 상태를 'Y'로 업데이트하고 읽어오는데 성공합니다.")
-    public void readAlarmSuccessOnUnreadExistingAlarm() {
-        when(alarmMapper.getAlarm(alarmId, to)).thenReturn(Optional.ofNullable(unreadAlarm));
-        doNothing().when(alarmMapper).updateToRead(alarmId, to);
-
-        alarmService.readAlarm(alarmId, to);
-
-        verify(alarmMapper, times(1)).getAlarm(alarmId, to);
-        verify(alarmMapper, times(1)).updateToRead(alarmId, to);
-    }
-
-    @Test
-    @DisplayName("해당 알람이 존재하고 기존에 읽었던 알람의 경우는 hasRead 의 상태를 변경하는 부가 작업 없이 알람을 바로 읽어오는데 성공합니다.")
-    public void readAlarmSuccessOnReadExistingAlarm() {
-        when(alarmMapper.getAlarm(alarmId, to)).thenReturn(Optional.ofNullable(readAlarm));
-
-        alarmService.readAlarm(alarmId, to);
-
-        verify(alarmMapper, times(1)).getAlarm(alarmId, to);
-        verify(alarmMapper, never()).updateToRead(alarmId, to);
-    }
-
-    @Test
-    @DisplayName("해당 알람이 더이상 존재하지 않는 경우 알림을 읽어오는데 실패하며 예외가 발생합니다.")
+    @DisplayName("해당 알람이 존재하지 않는 경우 hasRead 상태를 읽어오는데 실패하며 예외가 발생합니다.")
     public void readAlarmFailOnNotExistingAlarm() {
-        when(alarmMapper.getAlarm(alarmId, to)).thenReturn(Optional.empty());
+        when(alarmMapper.getHasReadStatus(alarmId, to)).thenReturn(Optional.empty());
 
         assertThrows(NoSuchAlarmException.class, () -> {
-           alarmService.readAlarm(alarmId, to);
+            alarmService.getAlarm(alarmId, to);
         });
 
-        verify(alarmMapper, times(1)).getAlarm(alarmId, to);
+        verify(alarmMapper, times(1)).getHasReadStatus(alarmId, to);
         verify(alarmMapper, never()).updateToRead(alarmId, to);
+        verify(alarmMapper, never()).getAlarm(alarmId, to);
+
     }
+
+    @Test
+    @DisplayName("해당 알람이 존재하여 기존에 읽지 않은 상태인 'N'을 리턴하는 경우 읽었다는 'Y'로 업데이트하고 알람을 읽어오는데 성공합니다.")
+    public void readAlarmSuccessOnExistingUnreadAlarm() {
+        String unRead = "N";
+        when(alarmMapper.getHasReadStatus(alarmId, to)).thenReturn(Optional.of(unRead));
+        doNothing().when(alarmMapper).updateToRead(alarmId, to);
+
+        alarmService.getAlarm(alarmId, to);
+
+        verify(alarmMapper, times(1)).getHasReadStatus(alarmId, to);
+        verify(alarmMapper, times(1)).updateToRead(alarmId, to);
+        verify(alarmMapper, times(1)).getAlarm(alarmId, to);
+    }
+
+    @Test
+    @DisplayName("해당 알람이 존재하여 기존에 읽은 상태인 'Y'를 리턴하는 경우 읽은 상태로 업데이트 하는 과정 없이 바로 알람을 읽어오는데 성공합니다.")
+    public void readAlarmSuccessOnExistingReadAlarm() {
+        String read = "Y";
+        when(alarmMapper.getHasReadStatus(alarmId, to)).thenReturn(Optional.of(read));
+
+        alarmService.getAlarm(alarmId, to);
+
+        verify(alarmMapper, times(1)).getHasReadStatus(alarmId, to);
+        verify(alarmMapper, never()).updateToRead(alarmId, to);
+        verify(alarmMapper, times(1)).getAlarm(alarmId, to);
+    }
+
 }

--- a/src/test/java/me/soo/helloworld/service/AlarmServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/AlarmServiceTest.java
@@ -1,0 +1,89 @@
+package me.soo.helloworld.service;
+
+import me.soo.helloworld.enumeration.AlarmTypes;
+import me.soo.helloworld.exception.InvalidRequestException;
+import me.soo.helloworld.exception.NoSuchAlarmException;
+import me.soo.helloworld.mapper.AlarmMapper;
+import me.soo.helloworld.model.alarm.Alarm;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Date;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+public class AlarmServiceTest {
+
+    private final String to = "Soo";
+
+    private final String from = "Not Soo";
+
+    private final int alarmId = 1;
+
+    private final Date createdDate = Date.valueOf("2021-03-15");
+
+    Alarm readAlarm;
+
+    Alarm unreadAlarm;
+
+    @InjectMocks
+    AlarmService alarmService;
+
+    @Mock
+    AlarmMapper alarmMapper;
+
+    @BeforeEach
+    public void createUnreadAlarm() {
+        readAlarm = new Alarm(alarmId, to, from, AlarmTypes.FRIEND_REQUEST_RECEIVED, "Y", createdDate);
+    }
+
+    @BeforeEach
+    public void createReadAlarm() {
+        unreadAlarm = new Alarm(alarmId, to, from, AlarmTypes.FRIEND_REQUEST_RECEIVED, "N", createdDate);
+    }
+
+    @Test
+    @DisplayName("해당 알람이 존재하고 기존에 읽지 않았을 경우 읽은 상태를 'Y'로 업데이트하고 읽어오는데 성공합니다.")
+    public void readAlarmSuccessOnUnreadExistingAlarm() {
+        when(alarmMapper.getAlarm(alarmId, to)).thenReturn(Optional.ofNullable(unreadAlarm));
+        doNothing().when(alarmMapper).updateToRead(alarmId, to);
+
+        alarmService.readAlarm(alarmId, to);
+
+        verify(alarmMapper, times(1)).getAlarm(alarmId, to);
+        verify(alarmMapper, times(1)).updateToRead(alarmId, to);
+    }
+
+    @Test
+    @DisplayName("해당 알람이 존재하고 기존에 읽었던 알람의 경우는 hasRead 의 상태를 변경하는 부가 작업 없이 알람을 바로 읽어오는데 성공합니다.")
+    public void readAlarmSuccessOnReadExistingAlarm() {
+        when(alarmMapper.getAlarm(alarmId, to)).thenReturn(Optional.ofNullable(readAlarm));
+
+        alarmService.readAlarm(alarmId, to);
+
+        verify(alarmMapper, times(1)).getAlarm(alarmId, to);
+        verify(alarmMapper, never()).updateToRead(alarmId, to);
+    }
+
+    @Test
+    @DisplayName("해당 알람이 더이상 존재하지 않는 경우 알림을 읽어오는데 실패하며 예외가 발생합니다.")
+    public void readAlarmFailOnNotExistingAlarm() {
+        when(alarmMapper.getAlarm(alarmId, to)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchAlarmException.class, () -> {
+           alarmService.readAlarm(alarmId, to);
+        });
+
+        verify(alarmMapper, times(1)).getAlarm(alarmId, to);
+        verify(alarmMapper, never()).updateToRead(alarmId, to);
+    }
+}

--- a/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
@@ -1,6 +1,5 @@
 package me.soo.helloworld.service;
 
-import me.soo.helloworld.enumeration.FriendStatus;
 import me.soo.helloworld.exception.DuplicateRequestException;
 import me.soo.helloworld.exception.InvalidRequestException;
 import me.soo.helloworld.mapper.FriendMapper;
@@ -33,6 +32,9 @@ public class FriendServiceTest {
 
     @Mock
     UserService userService;
+
+    @Mock
+    AlarmService alarmService;
 
     /*
         친구 요청을 보낼 때 발생할 수 있는 예외들


### PR DESCRIPTION
## 📖 Controller 계층 관련

### 📑   AlarmController

- 개별 알람 읽기 요청을 매핑할 `getAlarm` 메소드 추가

## 📖 Service 계층 관련

### 📑  AlarmService

- 개별 알람 읽기 요청에 대한 비즈니스 로직을 처리할 `getAlarm` 메소드 추가

- 알람이 존재하지 않는 경우 예외 발생

- 처음 알람을 읽을 때만 `hasRead` 값을 `Y`로 변경하고 그 뒤로는 조건을 체크하여 DB 연결을 생략

## 📖 Mapper 계층 관련

### 📑 AlarmMapper

- DB에서 개별 알람을 가져 올 `getAlarm` 메소드 추가

-  DB에서 알람의 존재 여부와 함께 읽은 상태의 값을 체크할 수 있도록 `getHasReadStatus` 메소드 추가

- 개별 알람을 읽은 경우 읽기 상태를 `Y`로 업데이트 하는 `updateToRead`  메소드 추가

### 📑 AlarmMapper.xml

- 위의 내용을 처리할 쿼리 추가

## 📖 예외 관련

### 📑 NoSuchAlarmException 클래스 추가

- 요청한 알람이 존재하지 않는 예외를 표시하기 위한 `NoSuchAlarmException` 클래스 추가

### 📑 ExceptionHandler에 예외 매핑

- 예외 제목과 메시지를 매핑 후 예외가 발생하면 상태코드 `404(Not Found)`를 리턴하도록 설정

## 📖 테스트 관련

### 📑 AlarmServiceTest 추가

- 위의 로직을 테스트할 단위 테스트 작성

### 📑 전체적인 로직을 포스트맨을 사용해 테스트