### PR TITLE
[#29] 사용자가 받은 알람 삭제 기능 구현

### DIFF
--- a/src/main/java/me/soo/helloworld/controller/AlarmController.java
+++ b/src/main/java/me/soo/helloworld/controller/AlarmController.java
@@ -28,4 +28,10 @@ public class AlarmController {
     public Alarm getAlarm(@CurrentUser String userId, @PathVariable("alarm-id") Integer alarmId) {
         return alarmService.getAlarm(alarmId, userId);
     }
+
+    @LoginRequired
+    @DeleteMapping("/{alarm-id}")
+    public void removeAlarm(@CurrentUser String userId, @PathVariable("alarm-id") Integer alarmId) {
+        alarmService.removeAlarm(alarmId, userId);
+    }
 }

--- a/src/main/java/me/soo/helloworld/mapper/AlarmMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/AlarmMapper.java
@@ -21,4 +21,10 @@ public interface AlarmMapper {
     public Optional<String> getHasReadStatus(@Param("alarmId") int alarmId, @Param("userId") String userId);
 
     public void updateToRead(@Param("alarmId") int alarmId, @Param("userId") String userId);
+
+    public boolean isAlarmExist(@Param("alarmId") int alarmId, @Param("userId") String userId);
+
+    public void deleteAlarm(@Param("alarmId") int alarmId, @Param("userId") String userId);
+
+    public void deleteDispatchedAlarm(AlarmData alarm);
 }

--- a/src/main/java/me/soo/helloworld/service/AlarmService.java
+++ b/src/main/java/me/soo/helloworld/service/AlarmService.java
@@ -21,7 +21,7 @@ public class AlarmService {
 
     private final Pagination pagination;
 
-    public void addAlarm(String to, String from, AlarmTypes type) {
+    public void dispatchAlarm(String to, String from, AlarmTypes type) {
         AlarmData alarm = AlarmData.create(to, from, type);
         alarmMapper.insertAlarm(alarm);
     }
@@ -44,5 +44,18 @@ public class AlarmService {
         if (hasRead.equals("N")) {
             alarmMapper.updateToRead(alarmId, userId);
         }
+    }
+
+    public void removeAlarm(int alarmId, String userId) {
+        if (!alarmMapper.isAlarmExist(alarmId, userId)) {
+            throw new NoSuchAlarmException("존재하지 않는 알림을 삭제할 수 없습니다. 알림 정보를 다시 한 번 확인해주세요");
+        }
+
+        alarmMapper.deleteAlarm(alarmId, userId);
+    }
+
+    public void removeDispatchedAlarm(String to, String from, AlarmTypes type) {
+        AlarmData alarm = AlarmData.create(to, from, type);
+        alarmMapper.deleteDispatchedAlarm(alarm);
     }
 }

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -31,6 +31,7 @@ public class FriendService {
 
     private final AlarmService alarmService;
 
+    @Transactional
     public void sendFriendRequest(String userId, String targetId) {
         TargetValidator.targetNotSelf(userId, targetId);
         TargetValidator.targetExistence(userService.isUserIdExist(targetId));
@@ -43,24 +44,27 @@ public class FriendService {
         validateFriendStatusDetail(status);
 
         friendMapper.sendFriendRequest(userId, targetId);
-        alarmService.addAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
+        alarmService.dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     public FriendStatus getFriendStatus(String userId, String targetId) {
         return friendMapper.getFriendStatus(userId, targetId);
     }
 
+    @Transactional
     public void cancelFriendRequest(String userId, String targetId) {
         FriendStatus status = getFriendStatus(userId, targetId);
         validateFriendStatus(status, FRIEND_REQUESTED);
         friendMapper.deleteFriend(userId, targetId);
+        alarmService.removeDispatchedAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
+    @Transactional
     public void acceptFriendRequest(String userId, String targetId) {
         FriendStatus status = getFriendStatus(userId, targetId);
         validateFriendStatus(status, FRIEND_REQUEST_RECEIVED);
         friendMapper.updateFriendRequest(userId, targetId, FRIEND);
-        alarmService.addAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_ACCEPTED);
+        alarmService.dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_ACCEPTED);
     }
 
     public void rejectFriendRequest(String userId, String targetId) {

--- a/src/main/resources/mappers/AlarmMapper.xml
+++ b/src/main/resources/mappers/AlarmMapper.xml
@@ -31,4 +31,18 @@
     <select id="getHasReadStatus" parameterType="map" resultType="String">
         SELECT hasRead FROM alarms WHERE id = #{alarmId} AND alarmTo = #{userId}
     </select>
+
+    <select id="isAlarmExist" parameterType="map" resultType="boolean">
+        SELECT EXISTS (SELECT id FROM alarms WHERE id = #{alarmId} AND alarmTo = #{userId})
+    </select>
+
+    <delete id="deleteAlarm" parameterType="map">
+        DELETE FROM alarms WHERE id = #{alarmId} AND alarmTo = #{userId}
+    </delete>
+
+    <delete id="deleteDispatchedAlarm" parameterType="me.soo.helloworld.model.alarm.AlarmData">
+
+        DELETE FROM alarms
+        WHERE alarmTo = #{to} AND alarmFrom = #{from} AND type = #{type}
+    </delete>
 </mapper>

--- a/src/test/java/me/soo/helloworld/service/AlarmServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/AlarmServiceTest.java
@@ -70,4 +70,28 @@ public class AlarmServiceTest {
         verify(alarmMapper, times(1)).getAlarm(alarmId, to);
     }
 
+    @Test
+    @DisplayName("해당 알람이 존재하지 않는 경우, 알람을 삭제하는데 실패하며 NoSuchAlarmException 이 발생합니다.")
+    public void removeAlarmFailOnNoExistingAlarm() {
+        when(alarmMapper.isAlarmExist(alarmId, to)).thenReturn(false);
+
+        assertThrows(NoSuchAlarmException.class, () -> {
+            alarmService.removeAlarm(alarmId, to);
+        });
+
+        verify(alarmMapper, times(1)).isAlarmExist(alarmId, to);
+        verify(alarmMapper, never()).deleteAlarm(alarmId, to);
+    }
+
+    @Test
+    @DisplayName("해당 알람이 존재하는 경우, 알람을 삭제하는데 성공합니다.")
+    public void removeAlarmSuccessOnExistingAlarm() {
+        when(alarmMapper.isAlarmExist(alarmId, to)).thenReturn(true);
+
+        alarmService.removeAlarm(alarmId, to);
+
+        verify(alarmMapper, times(1)).isAlarmExist(alarmId, to);
+        verify(alarmMapper, times(1)).deleteAlarm(alarmId, to);
+    }
+
 }

--- a/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
@@ -1,5 +1,6 @@
 package me.soo.helloworld.service;
 
+import me.soo.helloworld.enumeration.AlarmTypes;
 import me.soo.helloworld.exception.DuplicateRequestException;
 import me.soo.helloworld.exception.InvalidRequestException;
 import me.soo.helloworld.mapper.FriendMapper;
@@ -57,6 +58,7 @@ public class FriendServiceTest {
         verify(blockUserService, never()).isUserBlocked(userId, targetId);
         verify(friendMapper, never()).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).sendFriendRequest(userId, targetId);
+        verify(alarmService, never()).dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     @Test
@@ -72,6 +74,7 @@ public class FriendServiceTest {
         verify(blockUserService, never()).isUserBlocked(userId, targetId);
         verify(friendMapper, never()).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).sendFriendRequest(userId, targetId);
+        verify(alarmService, never()).dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     @Test
@@ -88,6 +91,7 @@ public class FriendServiceTest {
         verify(blockUserService,times(1)).isUserBlocked(userId, targetId);
         verify(friendMapper, never()).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).sendFriendRequest(userId, targetId);
+        verify(alarmService, never()).dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     @Test
@@ -105,6 +109,7 @@ public class FriendServiceTest {
         verify(blockUserService,times(1)).isUserBlocked(userId, targetId);
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).sendFriendRequest(userId, targetId);
+        verify(alarmService, never()).dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     @Test
@@ -122,6 +127,7 @@ public class FriendServiceTest {
         verify(blockUserService,times(1)).isUserBlocked(userId, targetId);
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).sendFriendRequest(userId, targetId);
+        verify(alarmService, never()).dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     @Test
@@ -139,6 +145,7 @@ public class FriendServiceTest {
         verify(blockUserService,times(1)).isUserBlocked(userId, targetId);
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).sendFriendRequest(userId, targetId);
+        verify(alarmService, never()).dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     @Test
@@ -154,6 +161,7 @@ public class FriendServiceTest {
         verify(blockUserService,times(1)).isUserBlocked(userId, targetId);
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, times(1)).sendFriendRequest(userId, targetId);
+        verify(alarmService, times(1)).dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     @Test
@@ -165,6 +173,7 @@ public class FriendServiceTest {
 
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, times(1)).deleteFriend(userId, targetId);
+        verify(alarmService, times(1)).removeDispatchedAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     @Test
@@ -178,6 +187,7 @@ public class FriendServiceTest {
 
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).deleteFriend(userId, targetId);
+        verify(alarmService, never()).removeDispatchedAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     @Test
@@ -191,6 +201,7 @@ public class FriendServiceTest {
 
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).deleteFriend(userId, targetId);
+        verify(alarmService, never()).removeDispatchedAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     @Test
@@ -204,6 +215,7 @@ public class FriendServiceTest {
 
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).deleteFriend(userId, targetId);
+        verify(alarmService, never()).removeDispatchedAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
     }
 
     @Test
@@ -215,6 +227,7 @@ public class FriendServiceTest {
 
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, times(1)).updateFriendRequest(userId, targetId, FRIEND);
+        verify(alarmService, times(1)).dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_ACCEPTED);
     }
 
     @Test
@@ -228,6 +241,7 @@ public class FriendServiceTest {
 
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).updateFriendRequest(userId, targetId, FRIEND);
+        verify(alarmService, never()).dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_ACCEPTED);
     }
 
     @Test
@@ -241,10 +255,11 @@ public class FriendServiceTest {
 
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).updateFriendRequest(userId, targetId, FRIEND);
+        verify(alarmService, never()).dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_ACCEPTED);
     }
 
     @Test
-    @DisplayName("사용자가 친구 요청을 보낸 대상과 이미 친구관계가 맺어진 경우 InvalidRequestException 이 발생하며 친구요청을 철회하는데 실패합니다.")
+    @DisplayName("사용자가 친구 요청을 보낸 대상과 이미 친구관계가 맺어진 경우 InvalidRequestException 이 발생하며 친구요청을 수락하는데 실패합니다.")
     public void acceptFriendRequestFailIfFriendStatusAlreadyFriended() {
         when(friendMapper.getFriendStatus(userId, targetId)).thenReturn(FRIEND);
 
@@ -254,6 +269,7 @@ public class FriendServiceTest {
 
         verify(friendMapper, times(1)).getFriendStatus(userId, targetId);
         verify(friendMapper, never()).updateFriendRequest(userId, targetId, FRIEND);
+        verify(alarmService, never()).dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_ACCEPTED);
     }
 
     @Test


### PR DESCRIPTION
## 📖 Controller 계층 관련

### 📑  AlarmController

- 알람 제거 요청을 받을 `removeAlarm` 메소드 추가

## 📖 Service 계층 관련

### 📑 AlarmService

- `알람 아이디`와 `사용자 아이디`를 기준으로 알람을 제거하는 로직을 처리할 `removeAlarm` 메소드 추가

- 친구추가 요청 철회 등의 로직 처리 시 보냈던 알람을 다시 제거할 수 있도록 `보낸 사용자`, `받은 사용자`, `알람 타입`을 기준으로 알람을 제거하는 로직을 처리하는 `removeDispatchedAlarm` 추가

- 알람을 보낸다는 의미에 더 맞도록 메소드 이름을 `addAlarm`에서 `dispatchAlarm`으로 변경

### 📑 FriendSerivce

- 친구 요청 철회 로직에 `removeDispatchedAlarm` 메소드 추가

- 친구추가요청 보내기/철회/수락 등의 로직이 한 트랜잭션 내에서 이루어질 수 있도록 `@Transactional` 어노테이션 부여

## 📖 Mapper 계층 관련

### 📑 AlarmMapper

- DB에서 알람을 삭제하기 전에 알람이 존재하는지 확인해 줄 `isAlarmExist` 메소드 추가

- DB에서 알람을 삭제해 줄 `deleteAlarm` 메소드 추가

- DB에 반영된 보낸 알람을 삭제해 줄 `deleteDispatched` 메소드 추가

### 📑 AlarmMapper.xml

- 위의 모든 내용을 처리할 수 있는 쿼리문들 추가

## 📖 테스트 관련

### 📑 AlarmServiceTest

- 알람 삭제 로직을 테스트할 수 있도록 테스트 작성

### 📑 FriendServiceTest

- FriendService에 추가한 코드가 반영될 수 있도록 각각의 테스트 메소드에 필요한 코드 추가

### 📑 작성한 전체 테스트 구동 및 포스트맨을 활용한 테스트