### PR TITLE
[#30] 다른 친구에게 추천글을 남길 수 있는 기능 추가

### DIFF
--- a/src/main/java/me/soo/helloworld/controller/RecommendationController.java
+++ b/src/main/java/me/soo/helloworld/controller/RecommendationController.java
@@ -1,0 +1,26 @@
+package me.soo.helloworld.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.soo.helloworld.annotation.CurrentUser;
+import me.soo.helloworld.annotation.LoginRequired;
+import me.soo.helloworld.model.recommendation.RecommendationRequest;
+import me.soo.helloworld.service.RecommendationService;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/recommendations")
+public class RecommendationController {
+
+    private final RecommendationService recommendationService;
+
+    @LoginRequired
+    @PostMapping("/to/{targetId}")
+    public void leaveReview(@CurrentUser String userId,
+                            @PathVariable String targetId,
+                            @Valid @RequestBody RecommendationRequest recommendationRequest) {
+        recommendationService.leaveRecommendation(userId, targetId, recommendationRequest.getContent());
+    }
+}

--- a/src/main/java/me/soo/helloworld/enumeration/AlarmTypes.java
+++ b/src/main/java/me/soo/helloworld/enumeration/AlarmTypes.java
@@ -10,7 +10,8 @@ import org.apache.ibatis.type.MappedTypes;
 public enum AlarmTypes implements EnumCategory {
 
     FRIEND_REQUEST_RECEIVED(1),
-    FRIEND_REQUEST_ACCEPTED(2);
+    FRIEND_REQUEST_ACCEPTED(2),
+    RECOMMENDATION_LEFT(3);
 
     private final int category;
 

--- a/src/main/java/me/soo/helloworld/mapper/FriendMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/FriendMapper.java
@@ -7,6 +7,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface FriendMapper {
@@ -22,4 +23,8 @@ public interface FriendMapper {
                                     @Param("status") FriendStatus status);
 
     public List<FriendList> getFriendList(FriendListRequest friendListRequest);
+
+    public Optional<Integer> getFriendshipDuration(@Param("userId") String userId,
+                                                   @Param("targetId") String targetId,
+                                                   @Param("status") FriendStatus status);
 }

--- a/src/main/java/me/soo/helloworld/mapper/RecommendationMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/RecommendationMapper.java
@@ -1,0 +1,12 @@
+package me.soo.helloworld.mapper;
+
+import me.soo.helloworld.model.recommendation.Recommendation;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface RecommendationMapper {
+
+    public boolean isRecommendationExist(String from, String to);
+
+    public void insertRecommendation(Recommendation recommendation);
+}

--- a/src/main/java/me/soo/helloworld/model/recommendation/Recommendation.java
+++ b/src/main/java/me/soo/helloworld/model/recommendation/Recommendation.java
@@ -1,0 +1,22 @@
+package me.soo.helloworld.model.recommendation;
+
+import lombok.Builder;
+
+@Builder
+public class Recommendation {
+
+    String from;
+
+    String to;
+
+    String content;
+
+    public static Recommendation create(String userId, String targetId, String content) {
+
+        return Recommendation.builder()
+                        .from(userId)
+                        .to(targetId)
+                        .content(content)
+                        .build();
+    }
+}

--- a/src/main/java/me/soo/helloworld/model/recommendation/Recommendation.java
+++ b/src/main/java/me/soo/helloworld/model/recommendation/Recommendation.java
@@ -5,11 +5,11 @@ import lombok.Builder;
 @Builder
 public class Recommendation {
 
-    String from;
+    private final String from;
 
-    String to;
+    private final String to;
 
-    String content;
+    private final String content;
 
     public static Recommendation create(String userId, String targetId, String content) {
 

--- a/src/main/java/me/soo/helloworld/model/recommendation/RecommendationRequest.java
+++ b/src/main/java/me/soo/helloworld/model/recommendation/RecommendationRequest.java
@@ -1,0 +1,14 @@
+package me.soo.helloworld.model.recommendation;
+
+import lombok.*;
+
+import javax.validation.constraints.Size;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecommendationRequest {
+
+    @Size(min = 2, max = 255, message = "추천 글은 2자 이상 255자 미만으로 작성해주세요.")
+    private String content;
+}

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -91,6 +91,11 @@ public class FriendService {
         return friendMapper.getFriendList(request);
     }
 
+    public int getFriendshipDuration(String userId, String targetId) {
+        return friendMapper.getFriendshipDuration(userId, targetId, FRIEND)
+                            .orElseThrow(() -> new InvalidRequestException("친구가 아닌 대상에 대해서는 해당 요청을 처리하는 것이 불가능합니다."));
+    }
+
     private void validateFriendStatus(FriendStatus currentStatus, FriendStatus targetStatus) {
         if (!currentStatus.equals(targetStatus)) {
             throw new InvalidRequestException("잘못된 status 로 부터의 접근입니다. 해당 요청을 처리할 수 없습니다.");

--- a/src/main/java/me/soo/helloworld/service/RecommendationService.java
+++ b/src/main/java/me/soo/helloworld/service/RecommendationService.java
@@ -1,0 +1,47 @@
+package me.soo.helloworld.service;
+
+import lombok.RequiredArgsConstructor;
+import me.soo.helloworld.enumeration.AlarmTypes;
+import me.soo.helloworld.exception.DuplicateRequestException;
+import me.soo.helloworld.exception.InvalidRequestException;
+import me.soo.helloworld.mapper.RecommendationMapper;
+import me.soo.helloworld.model.recommendation.Recommendation;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationService {
+
+    public static final int MINIMUM_DURATION_BOUNDARY = 16;
+
+    private final FriendService friendService;
+
+    private final RecommendationMapper recommendationMapper;
+
+    private final AlarmService alarmService;
+
+    @Transactional
+    public void leaveRecommendation(String from, String to, String content) {
+        int friendshipDuration = friendService.getFriendshipDuration(from, to);
+
+        validateOverMinimumDuration(friendshipDuration);
+        checkDuplicateRecommendation(from, to);
+
+        recommendationMapper.insertRecommendation(Recommendation.create(from, to, content));
+        alarmService.dispatchAlarm(to, from, AlarmTypes.RECOMMENDATION_LEFT);
+    }
+
+    private void validateOverMinimumDuration(int currentDuration) {
+        if (!(currentDuration >= MINIMUM_DURATION_BOUNDARY)) {
+            throw new InvalidRequestException("추천글 작성을 위한 기본 조건을 충족하지 못하셨습니다. 추천글은 친구로 맺어진 날부터 16일 째 되는날 작성이 가능해집니다.");
+        }
+    }
+
+    private void checkDuplicateRecommendation(String from, String to) {
+        if (recommendationMapper.isRecommendationExist(from, to)) {
+            throw new DuplicateRequestException("이미 추천글 작성을 마치셨습니다. 각 개별 사용자에 대한 추천글 작성은 단 한번만 가능합니다.");
+        }
+    }
+
+}

--- a/src/main/resources/mappers/FriendMapper.xml
+++ b/src/main/resources/mappers/FriendMapper.xml
@@ -24,7 +24,7 @@
 
     <update id="updateFriendRequest" parameterType="map">
 
-        UPDATE friends SET status = #{status}
+        UPDATE friends SET status = #{status}, friendedAt = NOW()
             WHERE (userId = #{userId} AND friendId = #{targetId})
                 OR (userId = #{targetId} AND friendId = #{userId})
     </update>
@@ -36,5 +36,13 @@
             WHERE userId = #{userId} AND status = #{status}
         ORDER BY id DESC
         LIMIT #{offset}, #{limit}
+    </select>
+
+    <select id="getFriendshipDuration" parameterType="map" resultType="Integer">
+
+        SELECT TO_DAYS(NOW()) - TO_DAYS(friendedAt) FROM friends
+        WHERE userId = #{userId}
+            AND friendId = #{targetId}
+            AND `status` = #{status}
     </select>
 </mapper>

--- a/src/main/resources/mappers/RecommendationMapper.xml
+++ b/src/main/resources/mappers/RecommendationMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="me.soo.helloworld.mapper.RecommendationMapper">
+
+    <select id="isRecommendationExist" parameterType="String" resultType="boolean">
+        SELECT EXISTS (SELECT id FROM recommendations WHERE recomFrom = #{from} AND recomTo = #{to})
+    </select>
+
+    <insert id="insertRecommendation" parameterType="me.soo.helloworld.model.recommendation.Recommendation">
+        INSERT INTO recommendations (recomTo, recomFrom, content) VALUES (#{to}, #{from}, #{content})
+    </insert>
+</mapper>

--- a/src/main/resources/sql/friends.sql
+++ b/src/main/resources/sql/friends.sql
@@ -4,8 +4,9 @@ create table friends
         primary key,
     userId   varchar(20) not null,
     friendId varchar(20) not null,
-    status   tinyint     not null
+    status   tinyint     not null,
+    friendedAt timestamp   null
 );
 
-create index friends_userId_index
-    on friends (userId);
+create index friends_userId_friendId_index
+    on friends (userId, friendId);

--- a/src/main/resources/sql/recommendations.sql
+++ b/src/main/resources/sql/recommendations.sql
@@ -1,0 +1,12 @@
+create table recommendations
+(
+    id        bigint auto_increment
+        primary key,
+    recomTo   varchar(20)                         not null,
+    recomFrom varchar(20)                         not null,
+    content   varchar(255)                        not null,
+    writtenAt timestamp default CURRENT_TIMESTAMP not null
+);
+
+create index recommendations_recomTo_recomFrom_index
+    on recommendations (recomTo, recomFrom);

--- a/src/test/java/me/soo/helloworld/service/RecommendationServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/RecommendationServiceTest.java
@@ -1,0 +1,182 @@
+package me.soo.helloworld.service;
+
+import me.soo.helloworld.enumeration.AlarmTypes;
+import me.soo.helloworld.exception.DuplicateRequestException;
+import me.soo.helloworld.exception.InvalidRequestException;
+import me.soo.helloworld.mapper.RecommendationMapper;
+import me.soo.helloworld.model.recommendation.Recommendation;
+import me.soo.helloworld.model.recommendation.RecommendationRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.validation.*;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class RecommendationServiceTest {
+
+    private final String userId = "msugo1";
+
+    private final String friendId = "notMsugo1";
+
+    private final int boundaryDuration = 16;
+
+    Validator validator;
+
+    @InjectMocks
+    RecommendationService recommendationService;
+
+    @Mock
+    FriendService friendService;
+
+    @Mock
+    RecommendationMapper recommendationMapper;
+
+    @Mock
+    AlarmService alarmService;
+
+    String recommendationContent;
+
+    @BeforeEach
+    public void writeRecommendationContent() {
+        recommendationContent = "He is such an amazing partner, who has your back at all times. He's a good command of his mother tongue." +
+                "So, you won't be disappointed with what he will teach you.";
+    }
+
+    @BeforeEach
+    public void initValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    /*
+        테스트 for 리뷰 등록 (leaveReview)
+
+        1. 친구여부 검사
+        2. 리뷰등록 조건 만족 여부 검사
+        3. 이미 남겨진 리뷰가 있는지 검사
+        4. 모든 조건 통과 후에 리뷰 등록 가능
+     */
+    @Test
+    @DisplayName("추천 글 요청이 지정된 사이즈(2자 이상 ~ 255자 이하)를 지키지 않는 빈칸과 함께 들어온 경우 validation 위반이 발생합니다.")
+    public void recommendationRequestMappingFailWithEmptyRecommendationContent() {
+        String emptyRecommendationContent = "";
+        Set<ConstraintViolation<RecommendationRequest>> violations = validator.validate(new RecommendationRequest(emptyRecommendationContent));
+        assertThat(violations).extracting(ConstraintViolation::getMessage).containsOnly("추천 글은 2자 이상 255자 미만으로 작성해주세요.");
+    }
+
+    @Test
+    @DisplayName("추천 글 요청이 지정된 사이즈(2자 이상 ~ 255자 이하)를 지키지 않는 크기인 1글자로 들어온 경우 validation 위반이 발생합니다.")
+    public void recommendationRequestMappingFailWithRightBelowMinimumBoundarySizeRecommendationContent() {
+        String emptyRecommendationContent = "한";
+        Set<ConstraintViolation<RecommendationRequest>> violations = validator.validate(new RecommendationRequest(emptyRecommendationContent));
+        assertThat(violations).extracting(ConstraintViolation::getMessage).containsOnly("추천 글은 2자 이상 255자 미만으로 작성해주세요.");
+    }
+
+    @Test
+    @DisplayName("추천 글 요청이 지정된 사이즈(2자 이상 ~ 255자 이하)를 지키는 최소값인 2글자로 들어온 경우 요청 매핑에 성공합니다.")
+    public void recommendationRequestMappingSuccessWithRightAboveMinimumBoundarySizeRecommendationContent() {
+        String recommendationCommentJustUnderBoundary = "감사";
+
+        Set<ConstraintViolation<RecommendationRequest>> violations = validator.validate(new RecommendationRequest(recommendationCommentJustUnderBoundary));
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("추천 글 요청이 지정된 사이즈(2자 이상 ~ 255자 이하)를 지키는 값인 255글자로 들어온 경우 요청 매핑에 성공합니다.")
+    public void recommendationRequestMappingSuccessWithRightBelowMaximumBoundarySizeRecommendationContent() {
+        // 255자 리뷰
+        String recommendationCommentJustUnderBoundary = "이 사이트를 통해서 ~를 만나기 전까지 저는 항상 연습 상대를 찾는데 목말라 있었습니다. 특히 원어민을 상대로" +
+                "더 자연스러운 표현을 배우기를 항상 고대하고 있었는데 마침내 필요한 부분이 충족되서 너무 만족합니다. ~는 바쁜 삶을 살고 있지만 자신이 시간이 날 때마다" +
+                "꼼꼼한 답변을 주는데 소홀하지 않으며, 제가 실수를 할 때마다 제대로 바로잡고 넘어갈 수 있도록 도와줍니다. 앞으로도 지속적으로 연락을 주고받으면서 서로 목표하는" +
+                "유창성에 다가갔으면 좋겠습니다..";
+
+        Set<ConstraintViolation<RecommendationRequest>> violations = validator.validate(new RecommendationRequest(recommendationCommentJustUnderBoundary));
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("추천 글 요청이 지정된 사이즈(2자 이상 ~ 255자 미만)를 넘는 값인 256글자로 들어온 경우 validation 위반이 발생합니다.")
+    public void recommendationRequestMappingFailWithOverBoundarySizeRecommendationContent() {
+        // 256자 리뷰
+        String recommendationCommentJustOverBoundary = "이 사이트를 통해서 ~를 만나기 전까지 저는 항상 연습 상대를 찾는데 목말라 있었습니다. 특히 원어민을 상대로" +
+                "더 자연스러운 표현을 배우기를 항상 고대하고 있었는데 마침내 필요한 부분이 충족되서 너무 만족합니다. ~는 바쁜 삶을 살고 있지만 자신이 시간이 날 때마다" +
+                "꼼꼼한 답변을 주는데 소홀하지 않으며, 제가 실수를 할 때마다 제대로 바로잡고 넘어갈 수 있도록 도와줍니다. 앞으로도 지속적으로 연락을 주고받으면서 서로 목표하는" +
+                "유창성에 다가갔으면 좋겠습니다...";
+
+        Set<ConstraintViolation<RecommendationRequest>> violations = validator.validate(new RecommendationRequest(recommendationCommentJustOverBoundary));
+        assertThat(violations).extracting(ConstraintViolation::getMessage).containsOnly("추천 글은 2자 이상 255자 미만으로 작성해주세요.");
+    }
+
+    @Test
+    @DisplayName("친구가 아닌 대상에게 추천글을 남기는 요청을 보낼 경우 처리에 실패하며 InvalidRequestException 이 발생합니다.")
+    public void leaveRecommendationFailToNonFriendUser() {
+        doThrow(InvalidRequestException.class).when(friendService).getFriendshipDuration(userId, friendId);
+
+        assertThrows(InvalidRequestException.class, () -> {
+            recommendationService.leaveRecommendation(userId, friendId, recommendationContent);
+        });
+
+        verify(friendService, times(1)).getFriendshipDuration(userId, friendId);
+        verify(recommendationMapper, never()).isRecommendationExist(userId, friendId);
+        verify(recommendationMapper, never()).insertRecommendation(Recommendation.create(userId, friendId, recommendationContent));
+        verify(alarmService, never()).dispatchAlarm(friendId, userId, AlarmTypes.RECOMMENDATION_LEFT);
+    }
+
+
+    @Test
+    @DisplayName("친구 상태가 기준일(16일) 넘게 지속되지 않은 대상에게 추천글을 남기는 요청이 들어오면 처리에 실패하며 InvalidRequestException 이 발생합니다.")
+    public void leaveRecommendationFailToFriendBeforeReviewConditionAchieved() {
+        int justUnderBoundaryDuration = 15;
+        when(friendService.getFriendshipDuration(userId, friendId)).thenReturn(justUnderBoundaryDuration);
+
+        assertThrows(InvalidRequestException.class, () -> {
+            recommendationService.leaveRecommendation(userId, friendId, recommendationContent);
+        });
+
+        verify(friendService, times(1)).getFriendshipDuration(userId, friendId);
+        verify(recommendationMapper, never()).isRecommendationExist(userId, friendId);
+        verify(recommendationMapper, never()).insertRecommendation(Recommendation.create(userId, friendId, recommendationContent));
+        verify(alarmService, never()).dispatchAlarm(friendId, userId, AlarmTypes.RECOMMENDATION_LEFT);
+    }
+
+    @Test
+    @DisplayName("추천글을 남기기 위한 친구 기간 기준을 만족했더라도 이미 남겨진 추천글이 있으면 추천글을 남기는데 실패하며 DuplicateRequestException 이 발생합니다.")
+    public void leaveRecommendationFailToFriendToWhomReviewHasAlreadyBeenLeft() {
+        when(friendService.getFriendshipDuration(userId, friendId)).thenReturn(boundaryDuration);
+        when(recommendationMapper.isRecommendationExist(userId, friendId)).thenReturn(true);
+
+        assertThrows(DuplicateRequestException.class, () -> {
+            recommendationService.leaveRecommendation(userId, friendId, recommendationContent);
+        });
+
+        verify(friendService, times(1)).getFriendshipDuration(userId, friendId);
+        verify(recommendationMapper, times(1)).isRecommendationExist(userId, friendId);
+        verify(recommendationMapper, never()).insertRecommendation(Recommendation.create(userId, friendId, recommendationContent));
+        verify(alarmService, never()).dispatchAlarm(friendId, userId, AlarmTypes.RECOMMENDATION_LEFT);
+    }
+
+    @Test
+    @DisplayName("추천글을 남기기 위한 기준 - 16일 이상 친구로서 기존에 남긴 추천글이 없을 것 - 을 모두 만족하는 경우 추천글을 남기는데 성공하며 대상에게는 추천글 등록 알림을 보냅니다.")
+    public void leaveRecommendationSuccessWithAllConditionsAreMet() {
+        when(friendService.getFriendshipDuration(userId, friendId)).thenReturn(boundaryDuration);
+        when(recommendationMapper.isRecommendationExist(userId, friendId)).thenReturn(false);
+
+        recommendationService.leaveRecommendation(userId, friendId, recommendationContent);
+
+        verify(friendService, times(1)).getFriendshipDuration(userId, friendId);
+        verify(recommendationMapper, times(1)).isRecommendationExist(userId, friendId);
+        verify(recommendationMapper, times(1)).insertRecommendation(refEq(Recommendation.create(userId, friendId, recommendationContent)));
+        verify(alarmService, times(1)).dispatchAlarm(friendId, userId, AlarmTypes.RECOMMENDATION_LEFT);
+    }
+}


### PR DESCRIPTION
## 📖 Model 관련

### 📑  RecommendationRequest 클래스 추가

- `@RequestBody`를 통해 추천글 요청이 들어왔을 때 이를 매핑할 인스턴스를 생성하는 클래스

- Validation의 `@Size` 어노테이션을 통해서 적정길이의 추천글이 아닐 경우 매핑에 fail하도록 설정

### 📑 Recommendation 클래스 추가

- DB에 추천글 정보를 저장할 때 `추천글에 대한 정보를 담은 Recommendation 인스턴스`를 생성하기 위한 클래스(Builder 패턴 활용)

## 📖 Enum 관련

### 📑 AlarmTypes

- 다른 친구에게 리뷰를 남겼을 때 해당 친구에게 알림을 보낼 때 사용할 상수 `RECOMMENDATION_LEFT` 추가

## 📖 Controller 계층 관련

### 📑 RecommendationController 클래스 추가

- 추천글 관련 요청이 들어오면 이에 대한 매핑을 담당할 클래스

- 추천글 남기기에 대한 요청을 매핑할 `leaveReview` 메소드 추가

## 📖 Service 계층 관련

### 📑 FriendService

- 리뷰를 남길 수 있기 위한 기준이 되는 `친구가 된 날로부터 지금까지의 기간`을 구하기 위한 `getFriendshipDuration` 메소드 추가

### 📑 RecommendationService 클래스 추가

- 리뷰를 남기기 위한 로직을 처리하기 위한 `leaveRecommendation` 메소드 추가

- 로직 처리 과정

1. 오늘을 기준으로 친구가 맺어진 `날짜와의 차이를 계산`한다.

2. 친구가 아니어서 `날짜가 null` 이거나 `기준에 미달할 경우` 추천글을 남기는데 `실패`한다. (16일 이상)

3. 이미 해당 친구에게 추천글을 남긴 적이 있는 지 검사하고 있으면 `중복 예외`가 발생한다. (각 사용자마다 1 친구 1 리뷰가 기준)

4. 모든 로직을 문제 없이 통과할 경우 리뷰를 남기고 알람을 발송한다.

## 📖 Mapper 관련

### 📑 FriendMapper

- DB에서 친구가 된 날부터 오늘까지 몇일이 지났는지 받아올 `getFriendshipDuration` 메소드 추가

- 친구가 아닐 경우 `친구가 된 날짜가 없어 Null이 리턴`되므로 `Optional`을 사용해서 이를 처리

### 📑 FriendMapper.xml

- 친구기간을 받아올 로직을 처리하기 위한 쿼리문 추가

- `친구가 된 날을` 표시하도록 `friends` 테이블에 `friendedAt` 칼럼 추가 및 친구가 맺어진 시점에서 `NOW() TIMESTAMP`가 자동으로 추가되도록 처리

### 📑 RecommendationMapper

- DB에 이미 해당 사용자로 부터 대상 친구에 대한 추천글이 남겨져 있는지 검사 할 `isRecommendationExist` 메소드 추가

- DB에 대상 친구에 대한 추천글을 추가할 메소드인 `insertRecommendation` 추가

### 📑 RecommendationMapper.xml

- 위의 로직을 처리하기 위한 쿼리문 추가

## 📖 기타

### 📑 friends.sql

- `friendedAt 칼럼 추가`와 검색 성능을 높이기 위해 `friendId를 인덱스로 추가`한  sql문 업데이트 반영

### 📑 recommendation.sql

- 추천 글 관련 로직을 DB에 담을 테이블인 `recommendations`에 대한 테이블 생성 쿼리문 추가

## 📖 테스트 관련

### 📑 RecommendationServiceTest 단위 테스트 추가

- 단위 테스트를 통해 `validation` 및 각 예외/성공 케이스들을 검증

### 📑 포스트맨을 활용한 전체 요청 처리 테스트