### PR TITLE
[#32] 친구에게 남긴 추천글을 수정할 기능 구현

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,14 +26,5 @@ pipeline {
                 }
             }
         }
-
-        stage('Integration Tests') {
-            steps {
-                script {
-                    sh 'mvn failsafe:integration-test'
-                    junit testResults: '**/target/failsafe-reports/*.xml', allowEmptyResults: true
-                }
-            }
-        }
     }
 }

--- a/src/main/java/me/soo/helloworld/controller/RecommendationController.java
+++ b/src/main/java/me/soo/helloworld/controller/RecommendationController.java
@@ -5,6 +5,7 @@ import me.soo.helloworld.annotation.CurrentUser;
 import me.soo.helloworld.annotation.LoginRequired;
 import me.soo.helloworld.model.recommendation.RecommendationRequest;
 import me.soo.helloworld.service.RecommendationService;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -16,11 +17,20 @@ public class RecommendationController {
 
     private final RecommendationService recommendationService;
 
+    @ResponseStatus(HttpStatus.CREATED)
     @LoginRequired
     @PostMapping("/to/{targetId}")
     public void leaveReview(@CurrentUser String userId,
                             @PathVariable String targetId,
                             @Valid @RequestBody RecommendationRequest recommendationRequest) {
         recommendationService.leaveRecommendation(userId, targetId, recommendationRequest.getContent());
+    }
+
+    @LoginRequired
+    @PutMapping("/{recom-id}")
+    public void modifyReview(@PathVariable("recom-id") Integer id,
+                             @CurrentUser String userId,
+                             @Valid @RequestBody RecommendationRequest modificationRequest) {
+        recommendationService.modifyRecommendation(id, userId, modificationRequest.getContent());
     }
 }

--- a/src/main/java/me/soo/helloworld/mapper/RecommendationMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/RecommendationMapper.java
@@ -2,6 +2,9 @@ package me.soo.helloworld.mapper;
 
 import me.soo.helloworld.model.recommendation.Recommendation;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.Optional;
 
 @Mapper
 public interface RecommendationMapper {
@@ -9,4 +12,9 @@ public interface RecommendationMapper {
     public boolean isRecommendationExist(String from, String to);
 
     public void insertRecommendation(Recommendation recommendation);
+
+    public Optional<Integer> getHowLongSinceWrittenAt(@Param("id") int id, @Param("from") String from);
+
+    public void updateRecommendation(@Param("id") int id, @Param("from") String from,
+                                     @Param("modifiedContent") String modifiedContent);
 }

--- a/src/main/java/me/soo/helloworld/model/recommendation/Recommendation.java
+++ b/src/main/java/me/soo/helloworld/model/recommendation/Recommendation.java
@@ -5,11 +5,11 @@ import lombok.Builder;
 @Builder
 public class Recommendation {
 
-    String from;
+    private final String from;
 
-    String to;
+    private final String to;
 
-    String content;
+    private final String content;
 
     public static Recommendation create(String userId, String targetId, String content) {
 

--- a/src/main/java/me/soo/helloworld/model/recommendation/RecommendationRequest.java
+++ b/src/main/java/me/soo/helloworld/model/recommendation/RecommendationRequest.java
@@ -4,8 +4,9 @@ import lombok.*;
 
 import javax.validation.constraints.Size;
 
+// 빈 객체만 만들어지는 불상사를 막기 위해 NoArgs 생성자의 AccessLevel 을 PRIVATE 로 설정
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class RecommendationRequest {
 

--- a/src/main/java/me/soo/helloworld/service/RecommendationService.java
+++ b/src/main/java/me/soo/helloworld/service/RecommendationService.java
@@ -15,6 +15,8 @@ public class RecommendationService {
 
     public static final int MINIMUM_DURATION_BOUNDARY = 16;
 
+    public static final int MAXIMUM_HOW_LONG_BOUNDARY = 2;
+
     private final FriendService friendService;
 
     private final RecommendationMapper recommendationMapper;
@@ -25,16 +27,33 @@ public class RecommendationService {
     public void leaveRecommendation(String from, String to, String content) {
         int friendshipDuration = friendService.getFriendshipDuration(from, to);
 
-        validateOverMinimumDuration(friendshipDuration);
+        validateLeaveRecommendationAvailability(friendshipDuration);
         checkDuplicateRecommendation(from, to);
 
         recommendationMapper.insertRecommendation(Recommendation.create(from, to, content));
         alarmService.dispatchAlarm(to, from, AlarmTypes.RECOMMENDATION_LEFT);
     }
 
-    private void validateOverMinimumDuration(int currentDuration) {
+    public void modifyRecommendation(int id, String from, String modifiedContent) {
+        int howLong = howLongSinceWrittenAt(id, from);
+        validateModificationAvailability(howLong);
+        recommendationMapper.updateRecommendation(id, from, modifiedContent);
+    }
+
+    public int howLongSinceWrittenAt(int id, String from) {
+        return recommendationMapper.getHowLongSinceWrittenAt(id, from)
+                                    .orElseThrow(() -> new InvalidRequestException("해당 추천글이 존재하지 않습니다. 존재하지 않는 추천글은 수정할 수 없습니다."));
+    }
+
+    private void validateLeaveRecommendationAvailability(int currentDuration) {
         if (!(currentDuration >= MINIMUM_DURATION_BOUNDARY)) {
             throw new InvalidRequestException("추천글 작성을 위한 기본 조건을 충족하지 못하셨습니다. 추천글은 친구로 맺어진 날부터 16일 째 되는날 작성이 가능해집니다.");
+        }
+    }
+
+    private void validateModificationAvailability(int currentHowLong) {
+        if (!(currentHowLong <= MAXIMUM_HOW_LONG_BOUNDARY)) {
+            throw new InvalidRequestException("추천글 수정은 오직 48시간(2일) 내에만 가능합니다. 해당 추천글은 이미 수정가능 기간을 초과하였습니다.");
         }
     }
 

--- a/src/main/resources/mappers/RecommendationMapper.xml
+++ b/src/main/resources/mappers/RecommendationMapper.xml
@@ -10,4 +10,16 @@
     <insert id="insertRecommendation" parameterType="me.soo.helloworld.model.recommendation.Recommendation">
         INSERT INTO recommendations (recomTo, recomFrom, content) VALUES (#{to}, #{from}, #{content})
     </insert>
+
+    <select id="getHowLongSinceWrittenAt" parameterType="map" resultType="Integer">
+
+        SELECT TO_DAYS(NOW()) - TO_DAYS(writtenAt) FROM recommendations
+        WHERE id = #{id} AND recomFrom = #{from}
+    </select>
+
+    <update id="updateRecommendation" parameterType="map">
+
+        UPDATE recommendations SET content = #{modifiedContent}
+        WHERE id = #{id} AND recomFrom = #{from}
+    </update>
 </mapper>


### PR DESCRIPTION
## 📖 Controller 계층 관련

### 📑  RecommendationController

- `leaveReview` 메소드가 요청을 반영하는데 성공하면 `HttpStatus.CREATED`를 리턴하도록 변경

- 추천글 수정 요청을 받아서 서비스 계층에 전달해줄 `modifyReview` 메소드 추가

## 📖 Service 계층 관련

### 📑 RecommendationService

- 들어온 수정 요청을 가지고 검증과정을 거쳐 `검증을 통과한 요청`의 경우는 Mapper로 전달해 줄 `modifyRecommendation` 메소드 추가

- 추천글이 `남겨진 시점으로부터의 날짜`를 반환해 줄 `howLongSinceWrittenAt` 메소드 추가

- 추천글이 `수정가능한 기간 내에 있는지 검증`해 줄 `validateModificationAvailability` 메소드 추가

- 추천글을 남길 수 있는지 검증해주는 메소드의 이름을 `validateLeaveRecommendationAvailability`로 변경

## 📖 Mapper 계층 관련

### 📑 RecommendationMapper

- DB에서 `현재 시점에서 추천글이 남겨진 시점의 날짜 차이`가 얼마나 되는지 계산해서 리턴해 줄 `getHowLongSinceWrittenAt` 메소드 추가 (Optional을 사용해서 NPE로 부터 안전하도록 변경)

- 서비스 계층에서 검증과정을 모두 통과한 추천글 수정요청을 DB에 반영할 수 있도록하는 `updateRecommendation` 메소드 추가

### 📑 RecommendationMapper.xml

- 위의 요청을 처리해 줄 쿼리문 추가

## 📖 Model 관련

### 📑 RecommendationRequest

- `빈 객체만 만들어지는 불상사`를 막기 위해 NoArgsConstructor에 접근제어자를 `private`로 설정

## 📖 테스트 관련

- 추천글 수정 요청 처리에 대한 비즈니스 로직을 검증할 단위 테스트 작성

- 포스트맨을 활용해 전반적인 테스트 및 추가한 메소드 동작 확인