### PR TITLE
[#38] 조건을 활용해 사용자를 검색할 수 있는 기능 구현하기

### DIFF
--- a/src/main/java/me/soo/helloworld/annotation/AgeRange.java
+++ b/src/main/java/me/soo/helloworld/annotation/AgeRange.java
@@ -1,0 +1,23 @@
+package me.soo.helloworld.annotation;
+
+import me.soo.helloworld.util.validator.AgeRangeValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = AgeRangeValidator.class)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AgeRange {
+
+    String message() default "나이를 검색조건으로 지정할 때, 최대나이는 100살 이상, 최소나이는 9살 이하로 내려갈 수 없으며, " +
+            "최소 나이는 항상 최대 나이보다 작은 값을 유지해야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/me/soo/helloworld/controller/ProfileController.java
+++ b/src/main/java/me/soo/helloworld/controller/ProfileController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.soo.helloworld.annotation.CurrentUser;
 import me.soo.helloworld.annotation.LoginRequired;
+import me.soo.helloworld.model.condition.SearchConditionsRequest;
 import me.soo.helloworld.model.user.UserProfile;
 import me.soo.helloworld.model.user.UserProfiles;
 import me.soo.helloworld.service.ProfileService;
@@ -11,6 +12,7 @@ import me.soo.helloworld.util.Pagination;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @Slf4j
@@ -36,5 +38,13 @@ public class ProfileController {
     public List<UserProfiles> getUserProfiles(@CurrentUser String userId,
                                               @RequestParam(required = false) Integer cursor) {
         return profileService.getUserProfiles(userId, Pagination.create(cursor, pageSize));
+    }
+
+    @LoginRequired
+    @PostMapping("/on/conditions")
+    public List<UserProfiles> searchUserProfiles(@Valid @RequestBody SearchConditionsRequest conditionsRequest,
+                                               @CurrentUser String userId,
+                                               @RequestParam(required = false) Integer cursor) {
+        return profileService.searchUserProfiles(conditionsRequest, userId, Pagination.create(cursor, pageSize));
     }
 }

--- a/src/main/java/me/soo/helloworld/mapper/ProfileMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/ProfileMapper.java
@@ -1,5 +1,6 @@
 package me.soo.helloworld.mapper;
 
+import me.soo.helloworld.model.condition.SearchConditions;
 import me.soo.helloworld.model.user.UserDataOnProfile;
 import me.soo.helloworld.model.user.UserProfiles;
 import me.soo.helloworld.util.Pagination;
@@ -16,4 +17,6 @@ public interface ProfileMapper {
 
     public List<UserProfiles> getUserProfiles(@Param("userId") String userId,
                                               @Param("pagination") Pagination pagination);
+
+    public List<UserProfiles> searchUserProfiles(SearchConditions conditions);
 }

--- a/src/main/java/me/soo/helloworld/model/condition/SearchConditions.java
+++ b/src/main/java/me/soo/helloworld/model/condition/SearchConditions.java
@@ -1,0 +1,34 @@
+package me.soo.helloworld.model.condition;
+
+import lombok.Builder;
+import lombok.Getter;
+import me.soo.helloworld.util.Pagination;
+
+import static me.soo.helloworld.util.validator.AgeRangeValidator.MAX_AGE_RANGE;
+import static me.soo.helloworld.util.validator.AgeRangeValidator.MIN_AGE_RANGE;
+
+@Getter
+@Builder
+public class SearchConditions {
+
+    SearchConditionsRequest conditions;
+
+    String currentUser;
+
+    Pagination pagination;
+
+    int defaultMaxAge;
+
+    int defaultMinAge;
+
+    public static SearchConditions create(SearchConditionsRequest conditionsRequest, String userId, Pagination pagination) {
+
+        return SearchConditions.builder()
+                                .conditions(conditionsRequest)
+                                .currentUser(userId)
+                                .pagination(pagination)
+                                .defaultMaxAge(MAX_AGE_RANGE)
+                                .defaultMinAge(MIN_AGE_RANGE)
+                                .build();
+    }
+}

--- a/src/main/java/me/soo/helloworld/model/condition/SearchConditions.java
+++ b/src/main/java/me/soo/helloworld/model/condition/SearchConditions.java
@@ -4,8 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import me.soo.helloworld.util.Pagination;
 
-import static me.soo.helloworld.util.validator.AgeRangeValidator.MAX_AGE_RANGE;
-import static me.soo.helloworld.util.validator.AgeRangeValidator.MIN_AGE_RANGE;
+import static me.soo.helloworld.util.validator.AgeRangeValidator.MAX_AGE_BOUND;
+import static me.soo.helloworld.util.validator.AgeRangeValidator.MIN_AGE_BOUND;
 
 @Getter
 @Builder
@@ -27,8 +27,8 @@ public class SearchConditions {
                                 .conditions(conditionsRequest)
                                 .currentUser(userId)
                                 .pagination(pagination)
-                                .defaultMaxAge(MAX_AGE_RANGE)
-                                .defaultMinAge(MIN_AGE_RANGE)
+                                .defaultMaxAge(MAX_AGE_BOUND)
+                                .defaultMinAge(MIN_AGE_BOUND)
                                 .build();
     }
 }

--- a/src/main/java/me/soo/helloworld/model/condition/SearchConditionsRequest.java
+++ b/src/main/java/me/soo/helloworld/model/condition/SearchConditionsRequest.java
@@ -1,5 +1,6 @@
 package me.soo.helloworld.model.condition;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import me.soo.helloworld.annotation.AgeRange;
@@ -11,6 +12,7 @@ import javax.validation.constraints.Pattern;
 import java.util.List;
 
 @Getter
+@Builder
 @AgeRange
 @RequiredArgsConstructor
 public class SearchConditionsRequest {
@@ -35,12 +37,12 @@ public class SearchConditionsRequest {
     @Nullable
     private final Integer livingTown;
 
-    @NotNull(message = "검색 시 상대방의 구사언어 정보는 필수로 입력하셔야 합니다.")
+    @NotNull(message = "사용자 검색 시 상대방의 구사언어 정보는 필수로 입력하셔야 합니다.")
     private final Integer speakLanguage;
 
-    @NotNull(message = "검색 시 상대방이 학습하고 있는 언어 정보는 필수로 입력하셔야 합니다.")
+    @NotNull(message = "사용자 검색 시 상대방이 학습하고 있는 언어 정보는 필수로 입력하셔야 합니다.")
     private final Integer learningLanguage;
 
-    @NotNull(message = "검색 시 상대방이 학습하고 있는 언어에 대한 언어 레벨정보는 필수로 입력하셔야 합니다.")
+    @NotNull(message = "사용자 검색 시 상대방이 학습하고 있는 언어에 대한 레벨정보는 필수로 입력하셔야 합니다.")
     private final List<LanguageLevel> learningLanguageLevel;
 }

--- a/src/main/java/me/soo/helloworld/model/condition/SearchConditionsRequest.java
+++ b/src/main/java/me/soo/helloworld/model/condition/SearchConditionsRequest.java
@@ -7,9 +7,9 @@ import me.soo.helloworld.annotation.AgeRange;
 import me.soo.helloworld.enumeration.LanguageLevel;
 import org.springframework.lang.Nullable;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-import java.util.List;
 import java.util.Set;
 
 @Getter
@@ -38,11 +38,13 @@ public class SearchConditionsRequest {
     @Nullable
     private final Integer livingTown;
 
-    @NotNull(message = "사용자 검색 시 상대방의 구사언어 정보는 필수로 입력하셔야 합니다.")
-    private final Integer speakLanguage;
+    @NotNull
+    @Min(message = "상대방의 구사 언어 이름을 올바르게 입력해주세요.", value = 1)
+    private final int speakLanguage;
 
-    @NotNull(message = "사용자 검색 시 상대방이 학습하고 있는 언어 정보는 필수로 입력하셔야 합니다.")
-    private final Integer learningLanguage;
+    @NotNull
+    @Min(message = "상대방의 학습 언어 이름을 올바르게 입력해주세요.", value = 1)
+    private final int learningLanguage;
 
     @NotNull(message = "사용자 검색 시 상대방이 학습하고 있는 언어에 대한 레벨정보는 필수로 입력하셔야 합니다.")
     private final Set<LanguageLevel> learningLanguageLevel;

--- a/src/main/java/me/soo/helloworld/model/condition/SearchConditionsRequest.java
+++ b/src/main/java/me/soo/helloworld/model/condition/SearchConditionsRequest.java
@@ -10,6 +10,7 @@ import org.springframework.lang.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @Builder
@@ -44,5 +45,5 @@ public class SearchConditionsRequest {
     private final Integer learningLanguage;
 
     @NotNull(message = "사용자 검색 시 상대방이 학습하고 있는 언어에 대한 레벨정보는 필수로 입력하셔야 합니다.")
-    private final List<LanguageLevel> learningLanguageLevel;
+    private final Set<LanguageLevel> learningLanguageLevel;
 }

--- a/src/main/java/me/soo/helloworld/model/condition/SearchConditionsRequest.java
+++ b/src/main/java/me/soo/helloworld/model/condition/SearchConditionsRequest.java
@@ -1,0 +1,46 @@
+package me.soo.helloworld.model.condition;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import me.soo.helloworld.annotation.AgeRange;
+import me.soo.helloworld.enumeration.LanguageLevel;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import java.util.List;
+
+@Getter
+@AgeRange
+@RequiredArgsConstructor
+public class SearchConditionsRequest {
+
+    @Nullable
+    @Pattern(message = "성별을 검색 조건으로 지정하기 위해서는 'M'(Male), 'F'(Female), 'O'(Other)의 세 조건 중 하나만 입력이 가능합니다.",
+            regexp = "^[MFO]$")
+    private final String gender;
+
+    @Nullable
+    private final Integer minAge;
+
+    @Nullable
+    private final Integer maxAge;
+
+    @Nullable
+    private final Integer originCountry;
+
+    @Nullable
+    private final Integer livingCountry;
+
+    @Nullable
+    private final Integer livingTown;
+
+    @NotNull(message = "검색 시 상대방의 구사언어 정보는 필수로 입력하셔야 합니다.")
+    private final Integer speakLanguage;
+
+    @NotNull(message = "검색 시 상대방이 학습하고 있는 언어 정보는 필수로 입력하셔야 합니다.")
+    private final Integer learningLanguage;
+
+    @NotNull(message = "검색 시 상대방이 학습하고 있는 언어에 대한 언어 레벨정보는 필수로 입력하셔야 합니다.")
+    private final List<LanguageLevel> learningLanguageLevel;
+}

--- a/src/main/java/me/soo/helloworld/model/recommendation/Recommendations.java
+++ b/src/main/java/me/soo/helloworld/model/recommendation/Recommendations.java
@@ -1,6 +1,5 @@
 package me.soo.helloworld.model.recommendation;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Value;
 
 import java.time.LocalDate;

--- a/src/main/java/me/soo/helloworld/model/user/User.java
+++ b/src/main/java/me/soo/helloworld/model/user/User.java
@@ -23,7 +23,8 @@ public class User {
     @NotBlank
     private final String email;
 
-    @NotBlank(message = "성별을 입력해주세요.")
+    @NotBlank(message = "성별을 입력해주세요. 'M'(Male), 'F'(Female), 'O'(Other) 중 하나만 입력이 가능합니다.")
+    @Pattern(regexp = "^[MFO]$")
     private final String gender;
 
     @NotNull(message = "생년월일을 입력해주세요.")

--- a/src/main/java/me/soo/helloworld/service/BlockUserService.java
+++ b/src/main/java/me/soo/helloworld/service/BlockUserService.java
@@ -8,7 +8,7 @@ import me.soo.helloworld.mapper.FriendMapper;
 import me.soo.helloworld.model.blockuser.BlockUserList;
 import me.soo.helloworld.model.blockuser.BlockUserListRequest;
 import me.soo.helloworld.util.Pagination;
-import me.soo.helloworld.util.TargetValidator;
+import me.soo.helloworld.util.validator.TargetUserValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,8 +25,8 @@ public class BlockUserService {
     private final BlockUserMapper blockUserMapper;
 
     public void blockUser(String userId, String targetId) {
-        TargetValidator.targetNotSelf(userId, targetId);
-        TargetValidator.targetExistence(userService.isUserActivated(targetId));
+        TargetUserValidator.targetNotSelf(userId, targetId);
+        TargetUserValidator.targetExistence(userService.isUserActivated(targetId));
 
         if (isUserBlocked(userId, targetId)) {
             throw new DuplicateRequestException("이미 차단된 사용자를 다시 차단할 수 없습니다.");

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -9,7 +9,7 @@ import me.soo.helloworld.mapper.FriendMapper;
 import me.soo.helloworld.model.friend.FriendList;
 import me.soo.helloworld.model.friend.FriendListRequest;
 import me.soo.helloworld.util.Pagination;
-import me.soo.helloworld.util.TargetValidator;
+import me.soo.helloworld.util.validator.TargetUserValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,8 +31,8 @@ public class FriendService {
 
     @Transactional
     public void sendFriendRequest(String userId, String targetId) {
-        TargetValidator.targetNotSelf(userId, targetId);
-        TargetValidator.targetExistence(userService.isUserActivated(targetId));
+        TargetUserValidator.targetNotSelf(userId, targetId);
+        TargetUserValidator.targetExistence(userService.isUserActivated(targetId));
 
         if (blockUserService.isUserBlocked(userId, targetId)) {
             throw new InvalidRequestException("차단되어 있는 사용자에게 친구 요청을 보낼 수 없습니다.");

--- a/src/main/java/me/soo/helloworld/service/ProfileService.java
+++ b/src/main/java/me/soo/helloworld/service/ProfileService.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static me.soo.helloworld.util.CacheNames.*;
@@ -60,7 +61,7 @@ public class ProfileService {
 
     @Transactional(readOnly = true)
     public List<UserProfiles> searchUserProfiles(SearchConditionsRequest conditionsRequest, String userId, Pagination pagination) {
-        List<LanguageLevel> learningLangLevels = conditionsRequest.getLearningLanguageLevel();
+        Set<LanguageLevel> learningLangLevels = conditionsRequest.getLearningLanguageLevel();
         LanguageLevelValidator.validateLevel(learningLangLevels, LanguageStatus.LEARNING);
 
         SearchConditions conditions = SearchConditions.create(conditionsRequest, userId, pagination);

--- a/src/main/java/me/soo/helloworld/service/ProfileService.java
+++ b/src/main/java/me/soo/helloworld/service/ProfileService.java
@@ -1,8 +1,13 @@
 package me.soo.helloworld.service;
 
 import lombok.RequiredArgsConstructor;
+import me.soo.helloworld.enumeration.LanguageLevel;
+import me.soo.helloworld.enumeration.LanguageStatus;
 import me.soo.helloworld.exception.InvalidRequestException;
+import me.soo.helloworld.exception.language.InvalidLanguageLevelException;
 import me.soo.helloworld.mapper.ProfileMapper;
+import me.soo.helloworld.model.condition.SearchConditions;
+import me.soo.helloworld.model.condition.SearchConditionsRequest;
 import me.soo.helloworld.model.language.Language;
 import me.soo.helloworld.model.language.LanguageDataForProfile;
 import me.soo.helloworld.model.user.UserProfile;
@@ -10,6 +15,7 @@ import me.soo.helloworld.model.user.UserDataOnProfile;
 import me.soo.helloworld.model.recommendation.RecommendationForProfile;
 import me.soo.helloworld.model.user.UserProfiles;
 import me.soo.helloworld.util.Pagination;
+import me.soo.helloworld.util.validator.LanguageLevelValidator;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
@@ -50,6 +56,15 @@ public class ProfileService {
     })
     public List<UserProfiles> getUserProfiles(String userId, Pagination pagination) {
         return profileMapper.getUserProfiles(userId, pagination);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserProfiles> searchUserProfiles(SearchConditionsRequest conditionsRequest, String userId, Pagination pagination) {
+        List<LanguageLevel> learningLangLevels = conditionsRequest.getLearningLanguageLevel();
+        LanguageLevelValidator.validateLevel(learningLangLevels, LanguageStatus.LEARNING);
+
+        SearchConditions conditions = SearchConditions.create(conditionsRequest, userId, pagination);
+        return profileMapper.searchUserProfiles(conditions);
     }
 
     private String matchCountry(Integer id) {

--- a/src/main/java/me/soo/helloworld/service/RecommendationService.java
+++ b/src/main/java/me/soo/helloworld/service/RecommendationService.java
@@ -9,7 +9,7 @@ import me.soo.helloworld.model.recommendation.RecommendationForProfile;
 import me.soo.helloworld.model.recommendation.Recommendation;
 import me.soo.helloworld.model.recommendation.Recommendations;
 import me.soo.helloworld.util.Pagination;
-import me.soo.helloworld.util.TargetValidator;
+import me.soo.helloworld.util.validator.TargetUserValidator;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,7 +61,7 @@ public class RecommendationService {
 
     @Transactional(readOnly = true)
     public List<Recommendations> getRecommendationsAboutTarget(String targetId, Pagination pagination, String userId) {
-        TargetValidator.targetExistence(userService.isUserActivated(targetId));
+        TargetUserValidator.targetExistence(userService.isUserActivated(targetId));
         return recommendationMapper.getRecommendationsAboutTarget(targetId, pagination, userId);
     }
 

--- a/src/main/java/me/soo/helloworld/util/CacheNames.java
+++ b/src/main/java/me/soo/helloworld/util/CacheNames.java
@@ -1,5 +1,9 @@
 package me.soo.helloworld.util;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CacheNames {
 
     public static final String ID = "id";

--- a/src/main/java/me/soo/helloworld/util/DataSourceTypes.java
+++ b/src/main/java/me/soo/helloworld/util/DataSourceTypes.java
@@ -1,5 +1,9 @@
 package me.soo.helloworld.util;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DataSourceTypes {
 
     public static final String MASTER_DB = "master";

--- a/src/main/java/me/soo/helloworld/util/validator/AgeRangeValidator.java
+++ b/src/main/java/me/soo/helloworld/util/validator/AgeRangeValidator.java
@@ -1,0 +1,32 @@
+package me.soo.helloworld.util.validator;
+
+import me.soo.helloworld.annotation.AgeRange;
+import me.soo.helloworld.model.condition.SearchConditionsRequest;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
+public class AgeRangeValidator implements ConstraintValidator<AgeRange, SearchConditionsRequest> {
+
+    public static final int MAX_AGE_RANGE = 99;
+
+    public static final int MIN_AGE_RANGE = 10;
+
+    @Override
+    public boolean isValid(SearchConditionsRequest condition, ConstraintValidatorContext context) {
+        if (condition.getMinAge() == null && condition.getMaxAge() == null) {
+            return true;
+        } else if (condition.getMaxAge() == null) {
+            return MIN_AGE_RANGE <= condition.getMinAge() && condition.getMinAge() <= MAX_AGE_RANGE;
+        } else if (condition.getMinAge() == null) {
+            return  MIN_AGE_RANGE <= condition.getMaxAge() && condition.getMaxAge() <= MAX_AGE_RANGE;
+        } else {
+            return MIN_AGE_RANGE <= condition.getMinAge()
+                    && condition.getMinAge() <= condition.getMaxAge()
+                    && condition.getMaxAge()< MAX_AGE_RANGE;
+        }
+    }
+}

--- a/src/main/java/me/soo/helloworld/util/validator/AgeRangeValidator.java
+++ b/src/main/java/me/soo/helloworld/util/validator/AgeRangeValidator.java
@@ -11,22 +11,30 @@ import javax.validation.constraintvalidation.ValidationTarget;
 @SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
 public class AgeRangeValidator implements ConstraintValidator<AgeRange, SearchConditionsRequest> {
 
-    public static final int MAX_AGE_RANGE = 99;
+    public static final int MAX_AGE_BOUND = 99;
 
-    public static final int MIN_AGE_RANGE = 10;
+    public static final int MIN_AGE_BOUND = 10;
 
     @Override
     public boolean isValid(SearchConditionsRequest condition, ConstraintValidatorContext context) {
-        if (condition.getMinAge() == null && condition.getMaxAge() == null) {
-            return true;
-        } else if (condition.getMaxAge() == null) {
-            return MIN_AGE_RANGE <= condition.getMinAge() && condition.getMinAge() <= MAX_AGE_RANGE;
-        } else if (condition.getMinAge() == null) {
-            return  MIN_AGE_RANGE <= condition.getMaxAge() && condition.getMaxAge() <= MAX_AGE_RANGE;
-        } else {
-            return MIN_AGE_RANGE <= condition.getMinAge()
-                    && condition.getMinAge() <= condition.getMaxAge()
-                    && condition.getMaxAge() <= MAX_AGE_RANGE;
-        }
+        Integer minAge = condition.getMinAge();
+        Integer maxAge = condition.getMaxAge();
+
+        if (isBothAgesNull(minAge, maxAge)) return true;
+        else if (minAge == null) return isTheOtherAgeValid(maxAge);
+        else if (maxAge == null) return isTheOtherAgeValid(minAge);
+        else return isBothAgesValid(minAge, maxAge);
+    }
+
+    private boolean isBothAgesNull(Integer minAge, Integer maxAge) {
+        return minAge == null && maxAge == null;
+    }
+
+    private boolean isTheOtherAgeValid(Integer age) {
+        return MIN_AGE_BOUND <= age && age <= MAX_AGE_BOUND;
+    }
+
+    private boolean isBothAgesValid(Integer minAge, Integer maxAge) {
+        return MIN_AGE_BOUND <= minAge && minAge <= maxAge && maxAge <= MAX_AGE_BOUND;
     }
 }

--- a/src/main/java/me/soo/helloworld/util/validator/AgeRangeValidator.java
+++ b/src/main/java/me/soo/helloworld/util/validator/AgeRangeValidator.java
@@ -26,7 +26,7 @@ public class AgeRangeValidator implements ConstraintValidator<AgeRange, SearchCo
         } else {
             return MIN_AGE_RANGE <= condition.getMinAge()
                     && condition.getMinAge() <= condition.getMaxAge()
-                    && condition.getMaxAge()< MAX_AGE_RANGE;
+                    && condition.getMaxAge() <= MAX_AGE_RANGE;
         }
     }
 }

--- a/src/main/java/me/soo/helloworld/util/validator/LanguageLevelValidator.java
+++ b/src/main/java/me/soo/helloworld/util/validator/LanguageLevelValidator.java
@@ -1,11 +1,14 @@
 package me.soo.helloworld.util.validator;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import me.soo.helloworld.enumeration.LanguageLevel;
 import me.soo.helloworld.enumeration.LanguageStatus;
 import me.soo.helloworld.exception.language.InvalidLanguageLevelException;
 
 import java.util.List;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class LanguageLevelValidator {
 
     /*

--- a/src/main/java/me/soo/helloworld/util/validator/LanguageLevelValidator.java
+++ b/src/main/java/me/soo/helloworld/util/validator/LanguageLevelValidator.java
@@ -1,0 +1,46 @@
+package me.soo.helloworld.util.validator;
+
+import me.soo.helloworld.enumeration.LanguageLevel;
+import me.soo.helloworld.enumeration.LanguageStatus;
+import me.soo.helloworld.exception.language.InvalidLanguageLevelException;
+
+import java.util.List;
+
+public class LanguageLevelValidator {
+
+    /*
+        1) 언어 추가 시 Status 에 맞게 언어 레벨을 설정했는지 확인하는 경우
+
+        * Status 가 Native 인 경우
+        - 추가하는 언어 모두 레벨이 NATIVE 로 이루어져 있어야 합니다.
+        * Status 가 Native 가 아닌 경우 (CAN_SPEAK or LEARNING)
+        - 어떤 언어도 레벨이 NATIVE 가 되어서는 안됩니다.
+
+        2) 프로필 조회 시 Status 에 맞게 언어 레벨을 설정했는지 확인하는 경우
+
+        * 프로필 조회 시 검색 조건으로 언어 레벨을 설정하는 부분은 Learning Language 에 대해서만 이루어집니다.
+        - 따라서 학습 중인 언어에 대한 언어 레벨 검색 시 레벨 조건에 Native 가 들어갈 수 없습니다.
+        - 이외에는 모든 레벨을 자유롭게 선택 가능합니다.
+ */
+    public static void validateLevel(List<LanguageLevel> levels, LanguageStatus status) {
+        boolean isLevelValid;
+
+        switch (status) {
+            case NATIVE:
+                isLevelValid = levels.stream().allMatch(level -> level.equals(LanguageLevel.NATIVE));
+                break;
+            case CAN_SPEAK:
+            case LEARNING:
+                isLevelValid = levels.stream().noneMatch(level -> level.equals(LanguageLevel.NATIVE));
+                break;
+            default:
+                throw new InvalidLanguageLevelException("해당 언어 status 는 존재하지 않습니다. 모국어(NATIVE), 구사 가능언어(CAN_SPEAK)," +
+                        " 학습 중인 언어(LEARNING) 중 한 가지만 선택해주세요.");
+        }
+
+        if (!isLevelValid) {
+            throw new InvalidLanguageLevelException("언어에 대한 레벨을 잘못 입력하셨습니다. 모국어의 언어 레벨은 NATIVE 레벨로만 설정이 가능하며," +
+                    " 모국어가 아닌 언어는 NATIVE 레벨로 설정이 불가능합니다.");
+        }
+    }
+}

--- a/src/main/java/me/soo/helloworld/util/validator/LanguageLevelValidator.java
+++ b/src/main/java/me/soo/helloworld/util/validator/LanguageLevelValidator.java
@@ -6,6 +6,7 @@ import me.soo.helloworld.enumeration.LanguageLevel;
 import me.soo.helloworld.enumeration.LanguageStatus;
 import me.soo.helloworld.exception.language.InvalidLanguageLevelException;
 
+import java.util.Collection;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -25,7 +26,7 @@ public class LanguageLevelValidator {
         - 따라서 학습 중인 언어에 대한 언어 레벨 검색 시 레벨 조건에 Native 가 들어갈 수 없습니다.
         - 이외에는 모든 레벨을 자유롭게 선택 가능합니다.
  */
-    public static void validateLevel(List<LanguageLevel> levels, LanguageStatus status) {
+    public static void validateLevel(Collection<LanguageLevel> levels, LanguageStatus status) {
         boolean isLevelValid;
 
         switch (status) {

--- a/src/main/java/me/soo/helloworld/util/validator/TargetUserValidator.java
+++ b/src/main/java/me/soo/helloworld/util/validator/TargetUserValidator.java
@@ -1,8 +1,11 @@
 package me.soo.helloworld.util.validator;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import me.soo.helloworld.exception.InvalidRequestException;
 import org.apache.commons.lang3.StringUtils;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TargetUserValidator {
 
     public static void targetNotSelf(String userId, String targetId) {

--- a/src/main/java/me/soo/helloworld/util/validator/TargetUserValidator.java
+++ b/src/main/java/me/soo/helloworld/util/validator/TargetUserValidator.java
@@ -1,9 +1,9 @@
-package me.soo.helloworld.util;
+package me.soo.helloworld.util.validator;
 
 import me.soo.helloworld.exception.InvalidRequestException;
 import org.apache.commons.lang3.StringUtils;
 
-public class TargetValidator {
+public class TargetUserValidator {
 
     public static void targetNotSelf(String userId, String targetId) {
         if (StringUtils.equals(userId, targetId)) {

--- a/src/main/resources/mappers/ProfileMapper.xml
+++ b/src/main/resources/mappers/ProfileMapper.xml
@@ -76,8 +76,9 @@
     </resultMap>
 
     <select id="getUserProfiles" parameterType="map"
-            resultMap="getUserProfilesMap">        SELECT id, userId, aboutMe,
-        profileImageName, profileImagePath
+            resultMap="getUserProfilesMap">
+        SELECT id, userId, aboutMe,
+               profileImageName, profileImagePath
         FROM users
         WHERE
         <if test="pagination.cursor != null">
@@ -92,5 +93,53 @@
     
     <select id="getTotalRecommendationsNums" parameterType="String" resultType="int">
         SELECT COUNT(recomTo) FROM recommendations WHERE recomTo = #{userId}
+    </select>
+
+    <select id="searchUserProfiles" resultMap="getUserProfilesMap">
+        SELECT
+            u.id AS id,
+            u.userId AS userId,
+            u.aboutMe AS aboutMe,
+            u.profileImageName AS profileImageName,
+            u.profileImagePath AS profileImagePath
+        FROM users AS u
+            INNER JOIN speak s ON u.userId = s.userId
+            INNER JOIN speak l ON u.userId = l.userId
+        WHERE
+        <if test="pagination.cursor != null">
+            u.id <![CDATA[<]]> #{pagination.cursor} AND
+        </if>
+        <if test="conditions.gender != null">
+            u.gender = #{conditions.gender} AND
+        </if>
+        <choose>
+            <when test="conditions.minAge != null and conditions.maxAge == null">
+                (FORMAT(DATEDIFF(CURDATE(), u.birthDay) / 365.25, 0) BETWEEN #{conditions.minAge} AND #{defaultMaxAge}) AND
+            </when>
+            <when test="conditions.minAge == null and conditions.maxAge != null">
+                (FORMAT(DATEDIFF(CURDATE(), u.birthDay) / 365.25, 0) BETWEEN #{defaultMinAge} AND #{conditions.maxAge}) AND
+            </when>
+            <when test="conditions.minAge != null and conditions.maxAge != null">
+                (FORMAT(DATEDIFF(CURDATE(), u.birthDay) / 365.25, 0) BETWEEN #{conditions.minAge} AND #{conditions.maxAge}) AND
+            </when>
+        </choose>
+        <if test="conditions.originCountry != null">
+            u.originCountry = #{conditions.originCountry} AND
+        </if>
+        <if test="conditions.livingCountry != null">
+            u.livingCountry = #{conditions.livingCountry} AND
+        </if>
+        <if test="conditions.livingTown != null">
+            u.livingTown = #{conditions.livingTown} AND
+        </if>
+            u.isDeactivated = 'N' AND
+            u.userId NOT IN (SELECT blockedBy FROM block WHERE blockId = #{currentUser}) AND
+            (s.langId = #{conditions.speakLanguage} AND
+             s.status IN (2, 3)) AND
+            (l.langId = #{conditions.learningLanguage} AND
+             l.level IN <foreach collection="conditions.learningLanguageLevel" item="level" open="(" close=")" separator=","> #{level} </foreach> AND
+             l.status = 1)
+        ORDER BY u.id DESC
+        LIMIT #{pagination.pageSize}
     </select>
 </mapper>

--- a/src/main/resources/mappers/ProfileMapper.xml
+++ b/src/main/resources/mappers/ProfileMapper.xml
@@ -88,7 +88,6 @@
         AND userId NOT IN (SELECT blockedBy FROM block WHERE blockId = #{userId})
         ORDER BY id DESC
         LIMIT #{pagination.pageSize}
-
     </select>
     
     <select id="getTotalRecommendationsNums" parameterType="String" resultType="int">

--- a/src/test/java/me/soo/helloworld/TestCountries.java
+++ b/src/test/java/me/soo/helloworld/TestCountries.java
@@ -22,15 +22,17 @@ public class TestCountries {
 
     public final static int MEXICO = 10;
 
-    public final static int SOUTH_KOREA = 11;
+    public final static int MOROCCO = 11;
 
-    public final static int SPAIN = 12;
+    public final static int SOUTH_KOREA = 12;
 
-    public final static int SWEDEN = 13;
+    public final static int SPAIN = 13;
 
-    public final static int UNITED_KINGDOM = 14;
+    public final static int SWEDEN = 14;
 
-    public final static int UNITED_STATES = 15;
+    public final static int UNITED_KINGDOM = 15;
 
-    public final static int OTHERS = 16;
+    public final static int UNITED_STATES = 16;
+
+    public final static int OTHERS = 17;
 }

--- a/src/test/java/me/soo/helloworld/TestTowns.java
+++ b/src/test/java/me/soo/helloworld/TestTowns.java
@@ -14,11 +14,13 @@ public class TestTowns {
 
     public final static int YORK = 6;
 
-    public final static int SEOUL = 7;
+    public final static int UK_OTHERS = 7;
 
-    public final static int BUSAN = 8;
+    public final static int SEOUL = 8;
 
-    public final static int GWANGJU = 9;
+    public final static int BUSAN = 9;
 
-    public final static int OTHERS = 10;
+    public final static int GWANGJU = 10;
+
+
 }

--- a/src/test/java/me/soo/helloworld/TestUsersFixture.java
+++ b/src/test/java/me/soo/helloworld/TestUsersFixture.java
@@ -1,0 +1,68 @@
+package me.soo.helloworld;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import me.soo.helloworld.model.user.User;
+
+import java.sql.Date;
+
+import static me.soo.helloworld.TestCountries.*;
+import static me.soo.helloworld.TestTowns.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TestUsersFixture {
+
+    public static final User CURRENT_USER = User.builder()
+            .userId("soo1045")
+            .password("soo1045")
+            .email("soo1045@gmail.com")
+            .gender("M")
+            .birthday(Date.valueOf("2009-01-01"))
+            .originCountry(SOUTH_KOREA)
+            .livingCountry(UNITED_KINGDOM)
+            .livingTown(NEWCASTLE)
+            .build();
+
+    public static final User TENS_MALE_FROM_UK_LIVING_LONDON = User.builder()
+            .userId("tensMale")
+            .password("tensMale")
+            .email("tensMale@gmail.com")
+            .gender("M")
+            .birthday(Date.valueOf("2009-01-01"))
+            .originCountry(UNITED_KINGDOM)
+            .livingCountry(UNITED_KINGDOM)
+            .livingTown(LONDON)
+            .build();
+
+    public static final User TENS_FEMALE_FROM_KOREA = User.builder()
+            .userId("tensFemale")
+            .password("tensFemale")
+            .email("tensFemale@gmail.com")
+            .gender("F")
+            .birthday(Date.valueOf("2009-01-01"))
+            .originCountry(SOUTH_KOREA)
+            .livingCountry(SOUTH_KOREA)
+            .build();
+
+    public static final User FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL = User.builder()
+            .userId("fortiesMale")
+            .password("fortiesMale")
+            .email("fortiesMale@gmail.com")
+            .gender("M")
+            .birthday(Date.valueOf("1977-01-01"))
+            .originCountry(UNITED_KINGDOM)
+            .livingCountry(SOUTH_KOREA)
+            .livingTown(SEOUL)
+            .build();
+
+    public static final User SEVENTIES_FEMALE_FROM_UK_LIVING_LIVERPOOL = User.builder()
+            .userId("seventiesFemale")
+            .password("seventiesFemale")
+            .email("seventiesFemale@gmail.com")
+            .gender("F")
+            .birthday(Date.valueOf("1947-01-01"))
+            .originCountry(UNITED_KINGDOM)
+            .livingCountry(UNITED_KINGDOM)
+            .livingTown(LIVERPOOL)
+            .build();
+}

--- a/src/test/java/me/soo/helloworld/integration/ITSearchProfilesTest.java
+++ b/src/test/java/me/soo/helloworld/integration/ITSearchProfilesTest.java
@@ -30,7 +30,7 @@ import static me.soo.helloworld.TestLanguages.KOREAN;
 import static me.soo.helloworld.TestTowns.ABERDEEN;
 import static me.soo.helloworld.TestTowns.LIVERPOOL;
 import static me.soo.helloworld.TestUsersFixture.*;
-import static me.soo.helloworld.util.validator.AgeRangeValidator.MIN_AGE_RANGE;
+import static me.soo.helloworld.util.validator.AgeRangeValidator.MIN_AGE_BOUND;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
@@ -331,7 +331,7 @@ public class ITSearchProfilesTest {
                 .speakLanguage(ENGLISH)
                 .learningLanguage(KOREAN)
                 .learningLanguageLevel(allLevelsWithoutNativeLevel)
-                .minAge(MIN_AGE_RANGE)
+                .minAge(MIN_AGE_BOUND)
                 .build();
 
         List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);

--- a/src/test/java/me/soo/helloworld/integration/ITSearchProfilesTest.java
+++ b/src/test/java/me/soo/helloworld/integration/ITSearchProfilesTest.java
@@ -1,4 +1,4 @@
-package me.soo.helloworld.service.profile;
+package me.soo.helloworld.integration;
 
 import me.soo.helloworld.enumeration.LanguageLevel;
 import me.soo.helloworld.enumeration.LanguageStatus;

--- a/src/test/java/me/soo/helloworld/service/profile/ITSearchProfilesTest.java
+++ b/src/test/java/me/soo/helloworld/service/profile/ITSearchProfilesTest.java
@@ -1,0 +1,422 @@
+package me.soo.helloworld.service.profile;
+
+import me.soo.helloworld.enumeration.LanguageLevel;
+import me.soo.helloworld.enumeration.LanguageStatus;
+import me.soo.helloworld.exception.language.InvalidLanguageLevelException;
+import me.soo.helloworld.model.condition.SearchConditionsRequest;
+import me.soo.helloworld.model.language.LanguageData;
+import me.soo.helloworld.model.user.UserProfiles;
+import me.soo.helloworld.service.BlockUserService;
+import me.soo.helloworld.service.LanguageService;
+import me.soo.helloworld.service.ProfileService;
+import me.soo.helloworld.service.UserService;
+import me.soo.helloworld.util.Pagination;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static me.soo.helloworld.TestCountries.SOUTH_KOREA;
+import static me.soo.helloworld.TestCountries.UNITED_KINGDOM;
+import static me.soo.helloworld.TestLanguages.ENGLISH;
+import static me.soo.helloworld.TestLanguages.KOREAN;
+import static me.soo.helloworld.TestTowns.ABERDEEN;
+import static me.soo.helloworld.TestTowns.LIVERPOOL;
+import static me.soo.helloworld.TestUsersFixture.*;
+import static me.soo.helloworld.util.validator.AgeRangeValidator.MIN_AGE_RANGE;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Transactional
+public class ITSearchProfilesTest {
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    LanguageService languageService;
+
+    @Autowired
+    BlockUserService blockUserService;
+
+    @Autowired
+    ProfileService profileService;
+
+    Pagination pagination;
+
+    List<LanguageData> nativeEnglish;
+
+    List<LanguageData> nativeKorean;
+
+    List<LanguageData> beginnerKorean;
+
+    List<LanguageData> beginnerEnglish;
+
+    List<LanguageData> intermediateKorean;
+
+    Set<LanguageLevel> allLevelsIncludingNativeLevel;
+
+    Set<LanguageLevel> allLevelsWithoutNativeLevel;
+
+    List<String> englishSpeakers;
+
+    List<String> koreanBeginners;
+
+    List<String> unitedKingdomOrigins;
+
+    List<String> unitedKingdomResidents;
+
+    List<String> koreaResidents;
+
+    @BeforeEach
+    public void initPagination() {
+        pagination = Pagination.create(null, 5);
+    }
+
+    @BeforeEach
+    public void initLanguages() {
+        nativeEnglish = new ArrayList<>();
+        nativeEnglish.add(new LanguageData(ENGLISH, LanguageLevel.NATIVE));
+
+        nativeKorean = new ArrayList<>();
+        nativeKorean.add(new LanguageData(KOREAN, LanguageLevel.NATIVE));
+
+        beginnerKorean = new ArrayList<>();
+        beginnerKorean.add(new LanguageData(KOREAN, LanguageLevel.BEGINNER));
+
+        beginnerEnglish = new ArrayList<>();
+        beginnerEnglish.add(new LanguageData(ENGLISH, LanguageLevel.BEGINNER));
+
+        intermediateKorean = new ArrayList<>();
+        intermediateKorean.add(new LanguageData(KOREAN, LanguageLevel.INTERMEDIATE));
+    }
+
+    @BeforeEach
+    public void initLanguageLevelConditions() {
+        allLevelsIncludingNativeLevel = Arrays.stream(LanguageLevel.values()).collect(Collectors.toUnmodifiableSet());
+        allLevelsWithoutNativeLevel = Arrays.stream(LanguageLevel.values()).filter(level -> !LanguageLevel.NATIVE.equals(level))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    @BeforeEach
+    public void initEnglishSpeakers() {
+        englishSpeakers = new ArrayList<>();
+        englishSpeakers.add(TENS_MALE_FROM_UK_LIVING_LONDON.getUserId());
+        englishSpeakers.add(FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getUserId());
+        englishSpeakers.add(SEVENTIES_FEMALE_FROM_UK_LIVING_LIVERPOOL.getUserId());
+    }
+
+    @BeforeEach
+    public void initKoreanBeginners() {
+        koreanBeginners = new ArrayList<>();
+        koreanBeginners.add(TENS_MALE_FROM_UK_LIVING_LONDON.getUserId());
+        koreanBeginners.add(FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getUserId());
+    }
+
+    @BeforeEach
+    public void initCountryResidents() {
+        unitedKingdomOrigins = new ArrayList<>();
+        unitedKingdomOrigins.add(TENS_MALE_FROM_UK_LIVING_LONDON.getUserId());
+        unitedKingdomOrigins.add(FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getUserId());
+        unitedKingdomOrigins.add(SEVENTIES_FEMALE_FROM_UK_LIVING_LIVERPOOL.getUserId());
+
+        unitedKingdomResidents = new ArrayList<>();
+        unitedKingdomResidents.add(TENS_MALE_FROM_UK_LIVING_LONDON.getUserId());
+        unitedKingdomResidents.add(SEVENTIES_FEMALE_FROM_UK_LIVING_LIVERPOOL.getUserId());
+
+        koreaResidents = new ArrayList<>();
+        koreaResidents.add(TENS_FEMALE_FROM_KOREA.getUserId());
+        koreaResidents.add(FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getUserId());
+    }
+
+    private void insertUsers() {
+        userService.userSignUp(TENS_MALE_FROM_UK_LIVING_LONDON);
+        userService.userSignUp(FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL);
+        userService.userSignUp(SEVENTIES_FEMALE_FROM_UK_LIVING_LIVERPOOL);
+
+        userService.userSignUp(TENS_FEMALE_FROM_KOREA);
+
+        userService.userSignUp(CURRENT_USER);
+    }
+
+    private void insertLanguages() {
+        languageService.addLanguages(TENS_MALE_FROM_UK_LIVING_LONDON.getUserId(), nativeEnglish, LanguageStatus.NATIVE);
+        languageService.addLanguages(TENS_MALE_FROM_UK_LIVING_LONDON.getUserId(), beginnerKorean, LanguageStatus.LEARNING);
+
+        languageService.addLanguages(FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getUserId(), nativeEnglish, LanguageStatus.NATIVE);
+        languageService.addLanguages(FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getUserId(), beginnerKorean, LanguageStatus.LEARNING);
+
+        languageService.addLanguages(SEVENTIES_FEMALE_FROM_UK_LIVING_LIVERPOOL.getUserId(), nativeEnglish, LanguageStatus.NATIVE);
+        languageService.addLanguages(SEVENTIES_FEMALE_FROM_UK_LIVING_LIVERPOOL.getUserId(), intermediateKorean, LanguageStatus.LEARNING);
+
+        languageService.addLanguages(TENS_FEMALE_FROM_KOREA.getUserId(), nativeKorean, LanguageStatus.NATIVE);
+        languageService.addLanguages(TENS_FEMALE_FROM_KOREA.getUserId(), beginnerEnglish, LanguageStatus.LEARNING);
+    }
+
+    @Test
+    @DisplayName("조건을 설정해서 사용자를 검색할 때 학습중인 언어 레벨에 NATIVE 가 포함될 시 검색에 실패하며 InvalidLanguageLevelException 이 발생합니다.")
+    public void searchUserProfilesByOnlyLanguagesFailWhenNativeIncludedInLearningLevel() {
+        insertUsers();
+        insertLanguages();
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(allLevelsIncludingNativeLevel)
+                .build();
+
+        assertThrows(InvalidLanguageLevelException.class, () -> {
+            profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+        });
+    }
+
+    @Test
+    @DisplayName("구사 언어와 학습 언어정보를 설정해서 사용자를 검색하면 해당 언어정보와 매칭하는 사용자만 반환합니다.")
+    public void searchingUserProfilesByCertainLanguageNameShowsOnlyMatchingUsers() {
+        insertUsers();
+        insertLanguages();
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(allLevelsWithoutNativeLevel)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertEquals(matchingProfiles.size(), 3);
+        assertTrue(matchingProfiles.stream().noneMatch(user -> TENS_FEMALE_FROM_KOREA.getUserId().equals(user.getUserId())));
+        assertTrue(matchingProfiles.stream().allMatch(englishSpeaker -> englishSpeakers.contains(englishSpeaker.getUserId())));
+    }
+
+
+    @Test
+    @DisplayName("구체적인 언어레벨 또한 설정해서 사용자를 검색하면 학습 언어의 레벨이 매칭하는 사용자의 프로필만 반환합니다. - 레벨: BEGINNER")
+    public void searchingUserProfilesByCertainLanguageNameAndBeginnerLevelShowsOnlyMatchingUsers() {
+        insertUsers();
+        insertLanguages();
+        Set<LanguageLevel> beginnerLevel = new HashSet<>();
+        beginnerLevel.add(LanguageLevel.BEGINNER);
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(beginnerLevel)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertEquals(matchingProfiles.size(), 2);
+        assertTrue(matchingProfiles.stream().noneMatch(user -> SEVENTIES_FEMALE_FROM_UK_LIVING_LIVERPOOL.getUserId().equals(user.getUserId())));
+        assertTrue(matchingProfiles.stream().allMatch(user -> koreanBeginners.contains(user.getUserId())));
+    }
+
+    @Test
+    @DisplayName("구체적인 언어레벨 또한 설정해서 사용자를 검색하면 학습 언어의 레벨이 매칭하는 사용자의 프로필만 반환합니다. - 레벨: Intermediate")
+    public void searchingUserProfilesByCertainLanguageNameAndIntermediateLevelShowsOnlyMatchingUsers() {
+        insertUsers();
+        insertLanguages();
+        Set<LanguageLevel> intermediateLevel = new HashSet<>();
+        intermediateLevel.add(LanguageLevel.INTERMEDIATE);
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(intermediateLevel)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertEquals(matchingProfiles.size(), 1);
+        assertTrue(matchingProfiles.stream().noneMatch(user -> koreanBeginners.contains(user.getUserId())));
+        assertTrue(matchingProfiles.stream().allMatch(user -> SEVENTIES_FEMALE_FROM_UK_LIVING_LIVERPOOL.getUserId().equals(user.getUserId())));
+    }
+
+    @Test
+    @DisplayName("필수 조건외에 선택조건인 출신 국가가 조건으로 설정될 경우 해당 조건에 해당하는 사용자의 프로필만 반환합니다. - 출신: UK")
+    public void searchingUserProfilesWithOriginCountryAsConditionShowsOnlyMatchingUsers() {
+        insertUsers();
+        insertLanguages();
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(allLevelsWithoutNativeLevel)
+                .originCountry(UNITED_KINGDOM)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertEquals(matchingProfiles.size(), 3);
+        assertTrue(matchingProfiles.stream().allMatch(user -> unitedKingdomOrigins.contains(user.getUserId())));
+        assertTrue(matchingProfiles.stream().noneMatch(user -> TENS_FEMALE_FROM_KOREA.getUserId().equals(user.getUserId())));
+    }
+
+    @Test
+    @DisplayName("필수 조건외에 선택조건으로 출신 국가와 거주 국가가 모두 설정될 경우 해당 조건에 해당하는 사용자의 프로필만 반환합니다. - 출신: UK, 거주: Korea")
+    public void searchingUserProfilesWithOriginAndLivingCountryAsConditionShowsOnlyMatchingUsers() {
+        insertUsers();
+        insertLanguages();
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(allLevelsWithoutNativeLevel)
+                .originCountry(UNITED_KINGDOM)
+                .livingCountry(SOUTH_KOREA)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertEquals(matchingProfiles.size(), 1);
+        assertTrue(matchingProfiles.stream().allMatch(user -> FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getUserId().equals(user.getUserId())));
+    }
+
+    @Test
+    @DisplayName("필수 조건외에 선택조건으로 출신 국가와 거주 국가 그리고 거주 도시가 모두 설정될 경우 해당 조건에 해당하는 사용자의 프로필만 반환합니다. - 출신: UK, 거주: UK, 거주도시: LIVERPOOL")
+    public void searchingUserProfilesWithOriginAndLivingCountryAndLivingTownAsConditionShowsOnlyMatchingUsers() {
+        insertUsers();
+        insertLanguages();
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(allLevelsWithoutNativeLevel)
+                .originCountry(UNITED_KINGDOM)
+                .livingCountry(UNITED_KINGDOM)
+                .livingTown(LIVERPOOL)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertEquals(matchingProfiles.size(), 1);
+        assertTrue(matchingProfiles.stream().allMatch(user -> SEVENTIES_FEMALE_FROM_UK_LIVING_LIVERPOOL.getUserId().equals(user.getUserId())));
+    }
+
+    @Test
+    @DisplayName("조건이 잘 설정되었더라도 경우 해당 조건에 맞는 사용자가 없으면 빈 리스트만 반환합니다.")
+    public void searchingUserProfilesNoMatchedUsersReturnsOnlyEmptyList() {
+        insertUsers();
+        insertLanguages();
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(allLevelsWithoutNativeLevel)
+                .originCountry(UNITED_KINGDOM)
+                .livingCountry(UNITED_KINGDOM)
+                .livingTown(ABERDEEN)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertTrue(matchingProfiles.isEmpty());
+    }
+
+    @Test
+    @DisplayName("필수 조건외에 선택조건으로 최소 나이를 설정한 경우 설정한 최소나이로부터 나이의 최대 범위인 99살까지의 대상만 리턴합니다. - 최소나이 10살")
+    public void searchingUserProfilesByMinAgeReturnsUsersFromTheMinToDefaultMaxAge() {
+        insertUsers();
+        insertLanguages();
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(allLevelsWithoutNativeLevel)
+                .minAge(MIN_AGE_RANGE)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertEquals(matchingProfiles.size(), 3);
+        assertTrue(matchingProfiles.stream().allMatch(user -> englishSpeakers.contains(user.getUserId())));
+    }
+
+    @Test
+    @DisplayName("필수 조건외에 선택조건으로 최대 나이를 설정한 경우 설정한 최소 나이인 10살까지의 설정한 최대 나이까지의 대상만 리턴합니다. - 설정: 최대나이 30살")
+    public void searchingUserProfilesByMaxAgeReturnsUsersFromDefaultMinToSetMaxAge() {
+        insertUsers();
+        insertLanguages();
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(allLevelsWithoutNativeLevel)
+                .maxAge(30)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertEquals(matchingProfiles.size(), 1);
+        assertTrue(matchingProfiles.stream().allMatch(user -> TENS_MALE_FROM_UK_LIVING_LONDON.getUserId().equals(user.getUserId())));
+    }
+
+    @Test
+    @DisplayName("필수 조건외에 선택조건으로 최소 및 최대 나이를 설정한 경우 설정한 최소 나이 부터 설정한 최대 나이까지의 대상만을 리턴합니다. - 설정: 최소나이 20살, 최대나이 50살")
+    public void searchingUserProfilesByMinAndMaxAgeReturnsUsersFromSetMinToSetMaxAge() {
+        insertUsers();
+        insertLanguages();
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(allLevelsWithoutNativeLevel)
+                .minAge(20)
+                .maxAge(50)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertEquals(matchingProfiles.size(), 1);
+        assertTrue(matchingProfiles.stream().allMatch(user -> FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getUserId().equals(user.getUserId())));
+    }
+
+    @Test
+    @DisplayName("설정한 필수, 선택 조건에 맞는 대상이 서비스 내에는 존재할지라도, 상대방이 현재 검색 중인 사용자를 차단했을 경우에는 대상의 프로필을 반환하지 않습니다.")
+    public void searchingUserProfilesReturnsEmptyResultsAboutAnyUsersBlockingCurrentUser() {
+        insertUsers();
+        insertLanguages();
+        blockUserService.blockUser(FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getUserId(), CURRENT_USER.getUserId());
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(allLevelsWithoutNativeLevel)
+                .minAge(20)
+                .maxAge(50)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertEquals(matchingProfiles.size(), 0);
+    }
+
+    @Test
+    @DisplayName("설정한 필수, 선택 조건에 맞는 대상이었으나 회원탈퇴로 비활성화 되어있는 사용자의 경우에는 해당 사용자의 프로필을 반환하지 않습니다.")
+    public void searchingUserProfilesReturnsEmptyResultsAboutAnyDeactivatedUsers() {
+        insertUsers();
+        insertLanguages();
+        assertTrue(userService.isUserActivated(FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getUserId()));
+        userService.userDeleteAccount(FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getUserId(), FORTIES_MALE_FROM_UK_LIVING_KOREA_SEOUL.getPassword());
+
+        SearchConditionsRequest request = SearchConditionsRequest.builder()
+                .speakLanguage(ENGLISH)
+                .learningLanguage(KOREAN)
+                .learningLanguageLevel(allLevelsWithoutNativeLevel)
+                .minAge(20)
+                .maxAge(50)
+                .build();
+
+        List<UserProfiles> matchingProfiles = profileService.searchUserProfiles(request, CURRENT_USER.getUserId(), pagination);
+
+        assertEquals(matchingProfiles.size(), 0);
+    }
+}

--- a/src/test/java/me/soo/helloworld/service/profile/ProfileServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/profile/ProfileServiceTest.java
@@ -1,4 +1,4 @@
-package me.soo.helloworld.service;
+package me.soo.helloworld.service.profile;
 
 import lombok.extern.slf4j.Slf4j;
 import me.soo.helloworld.enumeration.LanguageLevel;
@@ -8,6 +8,9 @@ import me.soo.helloworld.mapper.ProfileMapper;
 import me.soo.helloworld.model.language.LanguageDataForProfile;
 import me.soo.helloworld.model.recommendation.RecommendationForProfile;
 import me.soo.helloworld.model.user.UserDataOnProfile;
+import me.soo.helloworld.service.FetchNameService;
+import me.soo.helloworld.service.ProfileService;
+import me.soo.helloworld.service.RecommendationService;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/src/test/java/me/soo/helloworld/service/profile/SearchProfilesValidatorTest.java
+++ b/src/test/java/me/soo/helloworld/service/profile/SearchProfilesValidatorTest.java
@@ -11,23 +11,21 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 import static me.soo.helloworld.TestLanguages.ENGLISH;
 import static me.soo.helloworld.TestLanguages.KOREAN;
-import static me.soo.helloworld.util.validator.AgeRangeValidator.MAX_AGE_RANGE;
-import static me.soo.helloworld.util.validator.AgeRangeValidator.MIN_AGE_RANGE;
+import static me.soo.helloworld.util.validator.AgeRangeValidator.MAX_AGE_BOUND;
+import static me.soo.helloworld.util.validator.AgeRangeValidator.MIN_AGE_BOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SearchProfilesValidatorTest {
 
-    private final String noSpeakLangExceptionMessage = "사용자 검색 시 상대방의 구사언어 정보는 필수로 입력하셔야 합니다.";
+    private final String inappropriateSpeakLangExceptionMessage = "상대방의 구사 언어 이름을 올바르게 입력해주세요.";
 
-    private final String noLearningLangExceptionMessage = "사용자 검색 시 상대방이 학습하고 있는 언어 정보는 필수로 입력하셔야 합니다.";
+    private final String inappropriateLearningLangExceptionMessage = "상대방의 학습 언어 이름을 올바르게 입력해주세요.";
 
     private final String noLearningLangLevelsExceptionMessage = "사용자 검색 시 상대방이 학습하고 있는 언어에 대한 레벨정보는 필수로 입력하셔야 합니다.";
 
@@ -36,9 +34,9 @@ public class SearchProfilesValidatorTest {
     private final String inappropriateAgeRangeExceptionMessage = "나이를 검색조건으로 지정할 때, 최대나이는 100살 이상, 최소나이는 9살 이하로 내려갈 수 없으며, " +
             "최소 나이는 항상 최대 나이보다 작은 값을 유지해야 합니다.";
 
-    private final int belowMinAgeLimit = MIN_AGE_RANGE - 1;
+    private final int belowMinAgeLimit = MIN_AGE_BOUND - 1;
 
-    private final int aboveMaxAgeLimit = MAX_AGE_RANGE + 1;
+    private final int aboveMaxAgeLimit = MAX_AGE_BOUND + 1;
 
     Validator validator;
 
@@ -137,7 +135,7 @@ public class SearchProfilesValidatorTest {
         assertFalse(violations.isEmpty());
         assertEquals(violations.size(), 1);
         assertThat(violations).extracting(ConstraintViolation::getMessage)
-                .containsOnly(noSpeakLangExceptionMessage);
+                .containsOnly(inappropriateSpeakLangExceptionMessage);
     }
 
     @Test
@@ -153,7 +151,7 @@ public class SearchProfilesValidatorTest {
         assertFalse(violations.isEmpty());
         assertEquals(violations.size(), 1);
         assertThat(violations).extracting(ConstraintViolation::getMessage)
-                .containsOnly(noLearningLangExceptionMessage);
+                .containsOnly(inappropriateLearningLangExceptionMessage);
     }
 
     @Test
@@ -184,7 +182,7 @@ public class SearchProfilesValidatorTest {
         assertFalse(violations.isEmpty());
         assertEquals(violations.size(), 2);
         assertThat(violations).extracting(ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(noSpeakLangExceptionMessage, noLearningLangExceptionMessage);
+                .containsExactlyInAnyOrder(inappropriateSpeakLangExceptionMessage, inappropriateLearningLangExceptionMessage);
     }
 
     @Test
@@ -199,7 +197,7 @@ public class SearchProfilesValidatorTest {
         assertFalse(violations.isEmpty());
         assertEquals(violations.size(), 2);
         assertThat(violations).extracting(ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(noSpeakLangExceptionMessage, noLearningLangLevelsExceptionMessage);
+                .containsExactlyInAnyOrder(inappropriateSpeakLangExceptionMessage, noLearningLangLevelsExceptionMessage);
     }
 
     @Test
@@ -214,7 +212,7 @@ public class SearchProfilesValidatorTest {
         assertFalse(violations.isEmpty());
         assertEquals(violations.size(), 2);
         assertThat(violations).extracting(ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(noLearningLangExceptionMessage, noLearningLangLevelsExceptionMessage);
+                .containsExactlyInAnyOrder(inappropriateLearningLangExceptionMessage, noLearningLangLevelsExceptionMessage);
     }
 
     @Test
@@ -222,8 +220,8 @@ public class SearchProfilesValidatorTest {
     public void searchUserProfilesFailWithoutAnyObligatoryConditionsSelected() {
         notNullRequestWithNoMandatoryConditionsSelected = SearchConditionsRequest.builder()
                 .gender("M")
-                .minAge(MIN_AGE_RANGE)
-                .maxAge(MAX_AGE_RANGE)
+                .minAge(MIN_AGE_BOUND)
+                .maxAge(MAX_AGE_BOUND)
                 .build();
 
         Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(notNullRequestWithNoMandatoryConditionsSelected);
@@ -231,7 +229,7 @@ public class SearchProfilesValidatorTest {
         assertFalse(violations.isEmpty());
         assertEquals(violations.size(), 3);
         assertThat(violations).extracting(ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(noSpeakLangExceptionMessage, noLearningLangExceptionMessage, noLearningLangLevelsExceptionMessage);
+                .containsExactlyInAnyOrder(inappropriateSpeakLangExceptionMessage, inappropriateLearningLangExceptionMessage, noLearningLangLevelsExceptionMessage);
     }
 
     @Test
@@ -354,7 +352,7 @@ public class SearchProfilesValidatorTest {
     public void searchUnitProfilesSuccessWithMaxAgeAloneAtExactMaxAgeLimit() {
         onlyMaxAgeRequestWithinMaxAgeLimit = SearchConditionsRequest.builder()
                 .gender("M")
-                .maxAge(MAX_AGE_RANGE)
+                .maxAge(MAX_AGE_BOUND)
                 .speakLanguage(KOREAN)
                 .learningLanguage(ENGLISH)
                 .learningLanguageLevel(levels)
@@ -370,7 +368,7 @@ public class SearchProfilesValidatorTest {
     public void searchUnitProfilesSuccessWithMaxAgeAloneAtExactMinAgeLimit() {
         onlyMaxAgeRequestWithinMaxAgeLimit = SearchConditionsRequest.builder()
                 .gender("M")
-                .maxAge(MIN_AGE_RANGE)
+                .maxAge(MIN_AGE_BOUND)
                 .speakLanguage(KOREAN)
                 .learningLanguage(ENGLISH)
                 .learningLanguageLevel(levels)
@@ -424,7 +422,7 @@ public class SearchProfilesValidatorTest {
     public void searchUnitProfilesSuccessWithMinAgeAloneAtExactMaxAgeLimit() {
         onlyMinAgeRequestWithinMixAgeLimit = SearchConditionsRequest.builder()
                 .gender("M")
-                .maxAge(MAX_AGE_RANGE)
+                .maxAge(MAX_AGE_BOUND)
                 .speakLanguage(KOREAN)
                 .learningLanguage(ENGLISH)
                 .learningLanguageLevel(levels)
@@ -440,7 +438,7 @@ public class SearchProfilesValidatorTest {
     public void searchUnitProfilesSuccessWithMinAgeAloneAtExactMinAgeLimit() {
         onlyMinAgeRequestWithinMixAgeLimit = SearchConditionsRequest.builder()
                 .gender("M")
-                .maxAge(MIN_AGE_RANGE)
+                .maxAge(MIN_AGE_BOUND)
                 .speakLanguage(KOREAN)
                 .learningLanguage(ENGLISH)
                 .learningLanguageLevel(levels)
@@ -457,7 +455,7 @@ public class SearchProfilesValidatorTest {
         bothAgesRequestWithMinBelowMinAgeLimit = SearchConditionsRequest.builder()
                 .gender("M")
                 .minAge(belowMinAgeLimit)
-                .maxAge(MAX_AGE_RANGE)
+                .maxAge(MAX_AGE_BOUND)
                 .speakLanguage(KOREAN)
                 .learningLanguage(ENGLISH)
                 .learningLanguageLevel(levels)
@@ -476,7 +474,7 @@ public class SearchProfilesValidatorTest {
     public void searchUnitProfilesFailWithBothMinAndMaxAgesWithMaxOverMaxAgeLimit() {
         bothAgesRequestWithMaxOverMaxAgeLimit = SearchConditionsRequest.builder()
                 .gender("M")
-                .minAge(MIN_AGE_RANGE)
+                .minAge(MIN_AGE_BOUND)
                 .maxAge(aboveMaxAgeLimit)
                 .speakLanguage(KOREAN)
                 .learningLanguage(ENGLISH)
@@ -518,8 +516,8 @@ public class SearchProfilesValidatorTest {
     public void searchUnitProfilesFailWithBothMinAndMaxAgesWithinLimitButWithMinGreaterThanMax() {
         bothAgesRequestWithinLimitButMinGreaterThanMax = SearchConditionsRequest.builder()
                 .gender("M")
-                .minAge(MAX_AGE_RANGE)
-                .maxAge(MAX_AGE_RANGE - 1)
+                .minAge(MAX_AGE_BOUND)
+                .maxAge(MAX_AGE_BOUND - 1)
                 .speakLanguage(KOREAN)
                 .learningLanguage(ENGLISH)
                 .learningLanguageLevel(levels)
@@ -539,8 +537,8 @@ public class SearchProfilesValidatorTest {
     public void searchUnitProfilesSuccessWithBothMinAndMaxAgesWithinLimitAndWithMaxEqualOrGreaterThanMin() {
         bothAgesRequestWithinLimitAndMaxEqualOrGreaterThanMin = SearchConditionsRequest.builder()
                 .gender("M")
-                .minAge(MAX_AGE_RANGE)
-                .maxAge(MAX_AGE_RANGE)
+                .minAge(MAX_AGE_BOUND)
+                .maxAge(MAX_AGE_BOUND)
                 .speakLanguage(KOREAN)
                 .learningLanguage(ENGLISH)
                 .learningLanguageLevel(levels)
@@ -565,8 +563,8 @@ public class SearchProfilesValidatorTest {
         assertFalse(violations.isEmpty());
         assertEquals(violations.size(), 5);
         assertThat(violations).extracting(ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(inappropriateAgeRangeExceptionMessage, inappropriateGenderExceptionMessage, noSpeakLangExceptionMessage,
-                        noLearningLangExceptionMessage, noLearningLangLevelsExceptionMessage);
+                .containsExactlyInAnyOrder(inappropriateAgeRangeExceptionMessage, inappropriateGenderExceptionMessage, inappropriateSpeakLangExceptionMessage,
+                        inappropriateLearningLangExceptionMessage, noLearningLangLevelsExceptionMessage);
     }
 
     @Test
@@ -574,8 +572,8 @@ public class SearchProfilesValidatorTest {
     public void searchUnitProfilesSuccessWithAllConditionsValid() {
         allValidConditions = SearchConditionsRequest.builder()
                 .gender("M")
-                .minAge(MIN_AGE_RANGE)
-                .maxAge(MAX_AGE_RANGE)
+                .minAge(MIN_AGE_BOUND)
+                .maxAge(MAX_AGE_BOUND)
                 .speakLanguage(KOREAN)
                 .learningLanguage(ENGLISH)
                 .learningLanguageLevel(levels)

--- a/src/test/java/me/soo/helloworld/service/profile/SearchProfilesValidatorTest.java
+++ b/src/test/java/me/soo/helloworld/service/profile/SearchProfilesValidatorTest.java
@@ -1,0 +1,587 @@
+package me.soo.helloworld.service.profile;
+
+import me.soo.helloworld.enumeration.LanguageLevel;
+import me.soo.helloworld.model.condition.SearchConditionsRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static me.soo.helloworld.TestLanguages.ENGLISH;
+import static me.soo.helloworld.TestLanguages.KOREAN;
+import static me.soo.helloworld.util.validator.AgeRangeValidator.MAX_AGE_RANGE;
+import static me.soo.helloworld.util.validator.AgeRangeValidator.MIN_AGE_RANGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SearchProfilesValidatorTest {
+
+    private final String noSpeakLangExceptionMessage = "사용자 검색 시 상대방의 구사언어 정보는 필수로 입력하셔야 합니다.";
+
+    private final String noLearningLangExceptionMessage = "사용자 검색 시 상대방이 학습하고 있는 언어 정보는 필수로 입력하셔야 합니다.";
+
+    private final String noLearningLangLevelsExceptionMessage = "사용자 검색 시 상대방이 학습하고 있는 언어에 대한 레벨정보는 필수로 입력하셔야 합니다.";
+
+    private final String inappropriateGenderExceptionMessage = "성별을 검색 조건으로 지정하기 위해서는 'M'(Male), 'F'(Female), 'O'(Other)의 세 조건 중 하나만 입력이 가능합니다.";
+
+    private final String inappropriateAgeRangeExceptionMessage = "나이를 검색조건으로 지정할 때, 최대나이는 100살 이상, 최소나이는 9살 이하로 내려갈 수 없으며, " +
+            "최소 나이는 항상 최대 나이보다 작은 값을 유지해야 합니다.";
+
+    private final int belowMinAgeLimit = MIN_AGE_RANGE - 1;
+
+    private final int aboveMaxAgeLimit = MAX_AGE_RANGE + 1;
+
+    Validator validator;
+
+    List<LanguageLevel> levels;
+
+    /*
+        1. validator 필수 입력조건 테스트
+        - 검색을 위해 반드시 입력이 필요한 조건인 @NotNull 데이터 들이 존재하지 않을 때와 존재할 때 validator 가 제대로 검증하는지 테스트
+     */
+    SearchConditionsRequest notNullRequestWithoutSpeakLanguage;
+
+    SearchConditionsRequest notNullRequestWithoutLearningLanguage;
+
+    SearchConditionsRequest notNullRequestWithoutLearningLanguageLevels;
+
+    SearchConditionsRequest notNullRequestWithoutSpeakAndLearningLanguage;
+
+    SearchConditionsRequest notNullRequestWithoutSpeakLanguageAndLearningLanguageLevels;
+
+    SearchConditionsRequest notNullRequestWithoutLearningLanguageAndLearningLanguageLevels;
+
+    SearchConditionsRequest notNullRequestWithNoMandatoryConditionsSelected;
+
+    SearchConditionsRequest notNullRequestWithAllRequiredDataSelected;
+
+    /*
+        2. validator 선택 입력조건 테스트
+            * 성별은 'M'(Male), 'F'(Female), 'O'(Other) 만 조건으로 입력이 가능합니다. 잘못된 글자가 들어오는 경우 예외가 발생합니다.
+            * 나이는 최소값(minAge)과 최대값(maxAge)을 지정해 범위를 선택할 수 있습니다.
+                1) 최소값이 지정되지 않은 경우 기본 최소값은 10입니다.
+                2) 최대값이 지정되지 않은 경우 기본 최대값은 99입니다.
+                3) 최소값은 항상 최대값보다 같거나 작아야합니다.
+     */
+    SearchConditionsRequest genderRequestOtherThanOneOfMFO;
+
+    SearchConditionsRequest genderRequestWithM;
+
+    SearchConditionsRequest genderRequestWithF;
+
+    SearchConditionsRequest genderRequestWithO;
+
+    SearchConditionsRequest onlyMaxAgeRequestOverMaxAgeLimit;
+
+    SearchConditionsRequest onlyMaxAgeRequestWithinMaxAgeLimit;
+
+    SearchConditionsRequest onlyMaxAgeRequestBelowMinAgeLimit;
+
+    SearchConditionsRequest onlyMinAgeRequestOverMaxAgeLimit;
+
+    SearchConditionsRequest onlyMinAgeRequestWithinMixAgeLimit;
+
+    SearchConditionsRequest onlyMixAgeRequestBelowMinAgeLimit;
+
+    SearchConditionsRequest bothAgesRequestWithMinBelowMinAgeLimit;
+
+    SearchConditionsRequest bothAgesRequestWithMaxOverMaxAgeLimit;
+
+    SearchConditionsRequest bothAgesRequestWithMaxOverMaxAndMinBelowMinAgeLimit;
+
+    SearchConditionsRequest bothAgesRequestWithinLimitButMinGreaterThanMax;
+
+    SearchConditionsRequest bothAgesRequestWithinLimitAndMaxEqualOrGreaterThanMin;
+
+    /*
+        모든 조건이 유효하거나 유효하지 않을 때 테스트
+     */
+    SearchConditionsRequest noneValidConditions;
+
+    SearchConditionsRequest allValidConditions;
+
+    @BeforeEach
+    public void initValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @BeforeEach
+    public void insertLanguageLevels() {
+        levels = new ArrayList<>();
+        levels.add(LanguageLevel.BEGINNER);
+        levels.add(LanguageLevel.ELEMENTARY);
+        levels.add(LanguageLevel.INTERMEDIATE);
+        levels.add(LanguageLevel.UPPER_INTERMEDIATE);
+    }
+
+    @Test
+    @DisplayName("조건을 사용해 다른 사용자를 검색할 때 구사 가능 언어를 조건으로 선택하지 않으면 validation 위반이 발생합니다.")
+    public void searchUserProfilesFailWithoutSpeakLanguageSelected() {
+        notNullRequestWithoutSpeakLanguage = SearchConditionsRequest.builder()
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(notNullRequestWithoutSpeakLanguage);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(noSpeakLangExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("조건을 사용해 다른 사용자를 검색할 때 학습 중인 언어를 조건으로 선택하지 않으면 validation 위반이 발생합니다.")
+    public void searchUserProfilesFailWithoutLearningLanguageSelected() {
+        notNullRequestWithoutLearningLanguage = SearchConditionsRequest.builder()
+                .speakLanguage(KOREAN)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(notNullRequestWithoutLearningLanguage);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(noLearningLangExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("조건을 사용해 다른 사용자를 검색할 때 학습 중인 언어의 레벨에 대한 검색 범위를 선택하지 않으면 validation 위반이 발생합니다.")
+    public void searchUserProfilesFailWithoutLearningLanguageLevelsSelected() {
+        notNullRequestWithoutLearningLanguageLevels = SearchConditionsRequest.builder()
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(notNullRequestWithoutLearningLanguageLevels);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(noLearningLangLevelsExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("조건을 사용해 다른 사용자를 검색할 때 구사 가능 언어와 학습 중인 언어를 조건으로 선택하지 않으면 validation 위반이 발생합니다.")
+    public void searchUserProfilesFailWithoutBothSpeakAndLearningLanguageSelected() {
+        notNullRequestWithoutSpeakAndLearningLanguage = SearchConditionsRequest.builder()
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(notNullRequestWithoutSpeakAndLearningLanguage);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 2);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(noSpeakLangExceptionMessage, noLearningLangExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("조건을 사용해 다른 사용자를 검색할 때 구사 가능 언어와 학습 중인 언어의 레벨 범위를 조건으로 선택하지 않으면 validation 위반이 발생합니다.")
+    public void searchUserProfilesFailWithoutSpeakLanguageAndLearningLanguageLevelsSelected() {
+        notNullRequestWithoutSpeakLanguageAndLearningLanguageLevels = SearchConditionsRequest.builder()
+                .learningLanguage(ENGLISH)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(notNullRequestWithoutSpeakLanguageAndLearningLanguageLevels);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 2);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(noSpeakLangExceptionMessage, noLearningLangLevelsExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("조건을 사용해 다른 사용자를 검색할 때 학습 중인 언어와 해당 언어에 대한 레벨의 검색 범위를 조건으로 선택하지 않으면 validation 위반이 발생합니다.")
+    public void searchUserProfilesFailWithoutLearningLanguageAndLearningLanguageLevelsSelected() {
+        notNullRequestWithoutLearningLanguageAndLearningLanguageLevels = SearchConditionsRequest.builder()
+                .speakLanguage(KOREAN)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(notNullRequestWithoutLearningLanguageAndLearningLanguageLevels);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 2);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(noLearningLangExceptionMessage, noLearningLangLevelsExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("조건을 사용해 다른 사용자를 검색할 때 필수 선택 조건이 하나도 들어가 있지 않는 경우에도 validation 위반이 발생합니다.")
+    public void searchUserProfilesFailWithoutAnyObligatoryConditionsSelected() {
+        notNullRequestWithNoMandatoryConditionsSelected = SearchConditionsRequest.builder()
+                .gender("M")
+                .minAge(MIN_AGE_RANGE)
+                .maxAge(MAX_AGE_RANGE)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(notNullRequestWithNoMandatoryConditionsSelected);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 3);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(noSpeakLangExceptionMessage, noLearningLangExceptionMessage, noLearningLangLevelsExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("조건을 사용해 다른 사용자를 검색할 때 필수 정보가 모두 선택되어 있는 경우 validation 검증에 통과합니다.")
+    public void searchUserProfilesSuccessWithAllNecessaryConditionsSelected() {
+        notNullRequestWithAllRequiredDataSelected = SearchConditionsRequest.builder()
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(notNullRequestWithAllRequiredDataSelected);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("성별을 선택조건으로 지정해 다른 사용자를 검색할 때 M(Male), F(Female), O(Other) 중 한 글자가 아닌 다른 글자/단어를 사용해 요청을 보낼 시 validation 위반이 발생합니다.")
+    public void searchUserProfilesFailWithGenderOtherThanOneOfMFO() {
+        genderRequestOtherThanOneOfMFO = SearchConditionsRequest.builder()
+                .gender("MF")
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(genderRequestOtherThanOneOfMFO);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(inappropriateGenderExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("성별을 선택조건으로 지정해 다른 사용자를 검색할 때 M(Male), F(Female), O(Other) 중 한 글자인 M을 선택해 요청을 보낼 시 validation 검증에 통과합니다.")
+    public void searchUserProfilesSuccessWithGenderM() {
+        genderRequestWithM = SearchConditionsRequest.builder()
+                .gender("M")
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(genderRequestWithM);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("성별을 선택조건으로 지정해 다른 사용자를 검색할 때 M(Male), F(Female), O(Other) 중 한 글자인 F를 선택해 요청을 보낼 시 validation 검증에 통과합니다.")
+    public void searchUserProfilesSuccessWithGenderF() {
+        genderRequestWithF = SearchConditionsRequest.builder()
+                .gender("F")
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(genderRequestWithF);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("성별을 선택조건으로 지정해 다른 사용자를 검색할 때 M(Male), F(Female), O(Other) 중 한 글자인 O를 선택해 요청을 보낼 시 validation 검증에 통과합니다.")
+    public void searchUserProfilesSuccessWithGenderO() {
+        genderRequestWithO = SearchConditionsRequest.builder()
+                .gender("O")
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(genderRequestWithO);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("최대 나이만을 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최대 나이 조건이 최대 나이 제한보다 클 시 validation 위반이 발생합니다.")
+    public void searchUnitProfilesFailWithMaxAgeAloneOverMaxAgeLimit() {
+        onlyMaxAgeRequestOverMaxAgeLimit = SearchConditionsRequest.builder()
+                .gender("M")
+                .maxAge(aboveMaxAgeLimit)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(onlyMaxAgeRequestOverMaxAgeLimit);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(inappropriateAgeRangeExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("최대 나이만을 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최대 나이 조건이 최소 나이 제한의 범위보다 작을 시 validation 위반이 발생합니다.")
+    public void searchUnitProfilesFailWithMaxAgeAloneBelowMinAgeLimit() {
+        onlyMaxAgeRequestBelowMinAgeLimit = SearchConditionsRequest.builder()
+                .gender("M")
+                .maxAge(belowMinAgeLimit)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(onlyMaxAgeRequestBelowMinAgeLimit);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(inappropriateAgeRangeExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("최대 나이만을 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최대 나이 조건이 딱 최대 나이 제한의 경계일 경우 validation 검증을 통과합니다.")
+    public void searchUnitProfilesSuccessWithMaxAgeAloneAtExactMaxAgeLimit() {
+        onlyMaxAgeRequestWithinMaxAgeLimit = SearchConditionsRequest.builder()
+                .gender("M")
+                .maxAge(MAX_AGE_RANGE)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(onlyMaxAgeRequestWithinMaxAgeLimit);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("최대 나이만을 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최대 나이 조건이 딱 최소 나이 제한의 경계일 경우에도 validation 검증을 통과합니다.")
+    public void searchUnitProfilesSuccessWithMaxAgeAloneAtExactMinAgeLimit() {
+        onlyMaxAgeRequestWithinMaxAgeLimit = SearchConditionsRequest.builder()
+                .gender("M")
+                .maxAge(MIN_AGE_RANGE)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(onlyMaxAgeRequestWithinMaxAgeLimit);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("최소 나이만을 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최소 나이 조건이 최대 나이 제한 보다 클 경우 validation 위반이 발생합니다.")
+    public void searchUnitProfilesFailWithMinAgeAloneOverMaxAgeLimit() {
+        onlyMinAgeRequestOverMaxAgeLimit = SearchConditionsRequest.builder()
+                .gender("M")
+                .minAge(aboveMaxAgeLimit)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(onlyMinAgeRequestOverMaxAgeLimit);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(inappropriateAgeRangeExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("최소 나이만을 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최소 나이 조건이 최소 나이 제한 보다 작을 경우 validation 위반이 발생합니다.")
+    public void searchUnitProfilesFailWithMixAgeAloneBelowMinAgeLimit() {
+        onlyMixAgeRequestBelowMinAgeLimit = SearchConditionsRequest.builder()
+                .gender("M")
+                .maxAge(belowMinAgeLimit)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(onlyMixAgeRequestBelowMinAgeLimit);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(inappropriateAgeRangeExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("최소 나이만을 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최소 나이 조건이 기본 최대 나이 제한의 경계에 설정될 경우에도 validation 검증을 통과합니다.")
+    public void searchUnitProfilesSuccessWithMinAgeAloneAtExactMaxAgeLimit() {
+        onlyMinAgeRequestWithinMixAgeLimit = SearchConditionsRequest.builder()
+                .gender("M")
+                .maxAge(MAX_AGE_RANGE)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(onlyMinAgeRequestWithinMixAgeLimit);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("최소 나이만을 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최소 나이 조건이 기본 최소 나이 제한의 경계에 설정될 경우에도 validation 검증을 통과합니다.")
+    public void searchUnitProfilesSuccessWithMinAgeAloneAtExactMinAgeLimit() {
+        onlyMinAgeRequestWithinMixAgeLimit = SearchConditionsRequest.builder()
+                .gender("M")
+                .maxAge(MIN_AGE_RANGE)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(onlyMinAgeRequestWithinMixAgeLimit);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("최대, 최소 나이를 모두 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최소 나이 조건이 기본 최소 나이 제한보다 작을 경우 validation 위반이 발생합니다.")
+    public void searchUnitProfilesFailWithBothMinAndMaxAgesWithMinBelowMinAgeLimit() {
+        bothAgesRequestWithMinBelowMinAgeLimit = SearchConditionsRequest.builder()
+                .gender("M")
+                .minAge(belowMinAgeLimit)
+                .maxAge(MAX_AGE_RANGE)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(bothAgesRequestWithMinBelowMinAgeLimit);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(inappropriateAgeRangeExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("최대, 최소 나이를 모두 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최대 나이 조건이 기본 최대 나이 제한보다 클 경우 validation 위반이 발생합니다.")
+    public void searchUnitProfilesFailWithBothMinAndMaxAgesWithMaxOverMaxAgeLimit() {
+        bothAgesRequestWithMaxOverMaxAgeLimit = SearchConditionsRequest.builder()
+                .gender("M")
+                .minAge(MIN_AGE_RANGE)
+                .maxAge(aboveMaxAgeLimit)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(bothAgesRequestWithMaxOverMaxAgeLimit);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(inappropriateAgeRangeExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("최대, 최소 나이를 모두 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최소 나이 조건이 기본 최소 나이 제한보다 작고, " +
+            "최대 나이 조건이 기본 최대 나이 제한보다 클 경우 validation 위반이 발생합니다.")
+    public void searchUnitProfilesFailWithBothMinAndMaxAgesWithMaxOverMaxAndMinBelowMinAgeLimit() {
+        bothAgesRequestWithMaxOverMaxAndMinBelowMinAgeLimit = SearchConditionsRequest.builder()
+                .gender("M")
+                .minAge(belowMinAgeLimit)
+                .maxAge(aboveMaxAgeLimit)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(bothAgesRequestWithMaxOverMaxAndMinBelowMinAgeLimit);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(inappropriateAgeRangeExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("최대, 최소 나이를 모두 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최소, 최대 나이 조건이 모두 제한조건 범위 내에 존재하지만 " +
+            "최소 값이 최대 값보다 클 경우 validation 위반이 발생합니다.")
+    public void searchUnitProfilesFailWithBothMinAndMaxAgesWithinLimitButWithMinGreaterThanMax() {
+        bothAgesRequestWithinLimitButMinGreaterThanMax = SearchConditionsRequest.builder()
+                .gender("M")
+                .minAge(MAX_AGE_RANGE)
+                .maxAge(MAX_AGE_RANGE - 1)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(bothAgesRequestWithinLimitButMinGreaterThanMax);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 1);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsOnly(inappropriateAgeRangeExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("최대, 최소 나이를 모두 선택조건으로 지정해 다른 사용자를 검색할 때 설정된 최소, 최대 나이 조건이 모두 제한조건 범위 내에 존재하며 " +
+            "최대 값이 최소 값보다 크거나 같을 경우 validation 검증을 통과합니다.")
+    public void searchUnitProfilesSuccessWithBothMinAndMaxAgesWithinLimitAndWithMaxEqualOrGreaterThanMin() {
+        bothAgesRequestWithinLimitAndMaxEqualOrGreaterThanMin = SearchConditionsRequest.builder()
+                .gender("M")
+                .minAge(MAX_AGE_RANGE)
+                .maxAge(MAX_AGE_RANGE)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(bothAgesRequestWithinLimitAndMaxEqualOrGreaterThanMin);
+
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("필수 조건이 하나도 선택되지 않았고, 입력된 선택조건마저 정해진 범위를 벗어난 경우 모두 validation 위반을 일으킵니다.")
+    public void searchUnitProfilesFailWithNoConditionsValid() {
+        noneValidConditions = SearchConditionsRequest.builder()
+                .gender("MFO")
+                .minAge(belowMinAgeLimit)
+                .maxAge(aboveMaxAgeLimit)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(noneValidConditions);
+
+        assertFalse(violations.isEmpty());
+        assertEquals(violations.size(), 5);
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .containsExactlyInAnyOrder(inappropriateAgeRangeExceptionMessage, inappropriateGenderExceptionMessage, noSpeakLangExceptionMessage,
+                        noLearningLangExceptionMessage, noLearningLangLevelsExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("필수 조건이 모두 선택되고, 입력된 선택조건도 정해진 범위 내에 존재하는 경우 모두 validation 검증을 통과합니다.")
+    public void searchUnitProfilesSuccessWithAllConditionsValid() {
+        allValidConditions = SearchConditionsRequest.builder()
+                .gender("M")
+                .minAge(MIN_AGE_RANGE)
+                .maxAge(MAX_AGE_RANGE)
+                .speakLanguage(KOREAN)
+                .learningLanguage(ENGLISH)
+                .learningLanguageLevel(levels)
+                .build();
+
+        Set<ConstraintViolation<SearchConditionsRequest>> violations = validator.validate(allValidConditions);
+
+        assertTrue(violations.isEmpty());
+    }
+}

--- a/src/test/java/me/soo/helloworld/service/profile/SearchProfilesValidatorTest.java
+++ b/src/test/java/me/soo/helloworld/service/profile/SearchProfilesValidatorTest.java
@@ -12,7 +12,8 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 import static me.soo.helloworld.TestLanguages.ENGLISH;
@@ -41,7 +42,7 @@ public class SearchProfilesValidatorTest {
 
     Validator validator;
 
-    List<LanguageLevel> levels;
+    Set<LanguageLevel> levels;
 
     /*
         1. validator 필수 입력조건 테스트
@@ -116,7 +117,7 @@ public class SearchProfilesValidatorTest {
 
     @BeforeEach
     public void insertLanguageLevels() {
-        levels = new ArrayList<>();
+        levels = new HashSet<>();
         levels.add(LanguageLevel.BEGINNER);
         levels.add(LanguageLevel.ELEMENTARY);
         levels.add(LanguageLevel.INTERMEDIATE);


### PR DESCRIPTION
    📖 Model 관련

    📑  SearchConditionsRequest

    - 검색조건에 대한 요청을 받아 컨트롤러 계층으로 전달하는 객체를 만들 클래스

    📑 SerachConditions

    - 검증을 통과한 검색 조건들과 다른 필요한 조건들을 모두 모아 DB로 전달하기 전 하나의 객체로 만들어 줄때 사용될 클래스

    📖 Controller 계층 관련

    📑 ProfileController

    - 조건을 설정해서 사용자를 검색하는 요청을 받는 `searchUserProfiles` 메소드 추가

    - validator와 `@Valid` 어노테이션을 활용해 `@RequestBody`를 통해 요청받은 값들을 일차적으로 검증할 수 있도록 설계

   📖 Service 계층 관련

    📑 ProfileService

    - 검색조건에 대한 로직을 처리할 `searchUserProfiles` 메소드 추가

    - 검색조건 중 학습 언어에 대한 언어 레벨 검증 실시(NATIVE 레벨이 조건에 추가되어 있지는 않은지)

    - 검증이 끝나면 요청받은 조건과 현재 로그인 중인 사용자의 아이디 그리고 cursor 기반 페이징 값을 모두 합쳐서 하나의 `conditions` 객체 생성

    - 특히, 나이의 경우 기본 최소, 최댓값을 부여함으로써 null 값이 들어오더라도 DB에서 유연하게 처리할 수 있도록 시도

    📑 LanguageService

    - 언어 레벨 검증에 대한 로직이 `ProfileService`에도 사용이 되므로 기존에 private 메소드로 LanguageService 내부에 존재했던 검증 메소드를 외부 static 메소드로 추출, 별도의 클래스 생성

    - 로직 변경에 따라 언어 레벨만을 담은 리스트를 추출해주는 private 메소드를 대신 생성 후, 해당 리스트를 위의 검증 메소드로 전달할 수 있도록 로직 변경

    📖 Mapper 계층 관련

    📑 ProfileMapper

    - 전달 받은 검색 조건을 가지고 DB에서 적절한 값을 찾아올 `searchUserProfiles` 메소드 추가

    📑 ProfileMapper.xml

    - 위의 검색 조건을 처리할 수 있도록 쿼리 작성 및 튜닝

    Annotation 관련

    📑 AgeRange

    - 커스텀 Validator 적용을 표시할 커스텀 어노테이션 생성

    - validation 위반 발생 시 예외를 던지면서 함께 전달할 기본 메시지 추가

    📖 Util 관련

    📑 AgeRangeValidator

    - 나이를 검색 조건으로 전달 받는 경우 터무니 없는 숫자가 들어오는 것을 막기 위해 나이의 최소값과 최대값을 설정할 필요

    - 기존의 @min, @max 어노테이션을 활용하면 쉽게 정수 값을 검증할 수 있었으나 개별 값들만 검증 가능하고, 연계된 값들을 검증하는데 사용할 수 있는 validator는 없었기에 커스텀 validator를 생성

    - 최솟값은 10살, 최댓값은 99살으로 설정하고 좀 더 유연한 유지보수를 위해 두 값을 상수로 생성해서 사용할 수 있도록 만듦

    - 나이 조건은 nullable 하므로 각 조건을 4개의 분기로 나눠 요청으로 들어오는 조건이 최대, 최소값을 초과할 수 없도록 하였으며, 최솟값의 경우에도 최댓값을 넘을 수 없도록 코드 작성

    📑 LanguageRangeValidator

    - 기존 언어 레벨을 검증하는 메소드는 LanguageService 내부에 private 메소드로 별도로 존재했으나, 프로필을 검색하면서 레벨 조건을 설정하기 때문에 맞는 레벨이 들어왔는지 검증할 필요성이 생김

    - 중복 코드 작성을 없애기 위해서 별도의 Validator 클래스를 생성하고 내부에 레벨 검증 메소드를 static 메소드로 둠으로써 필요한 클래스들에서  바로 활용할 수 있도록 변경

   📖  테스트 코드 작성

    🔖 TestUsersFixture

    - 테스트에 사용할 유저들의 Fixture을 한 곳에 모아놓은 클래스 생성

    🔖 ITSearchProfilesTest

    - 필수 조건과 선택 조건을 적용한 통합 테스트 메소드 작성 후 적절한 결과가 나오는지 검증

    🔖 ProfileService

    - 컨트롤러 요청으로 들어온 언어 레벨에 중복되는 값이 있는지 검사할 필요가 없도록 List 자체를 Set으로 변경

    🔖 LanguageLevelValidator

    - `List와 Set 타입이 모두` 적절한 언어 레벨인지 검증할 수 있는 메소드를 사용할 수 있도록 파라미터의 타입을 List에서 `Collection`으로 변경

    🔖 User

    - 성별을 입력하는 칸에 정규표현식을 추가해서 원하는 값만 들어올 수 있도록 검증과정 추가