### PR TITLE
[#41] Firebase Cloud Messaging을 활용한 Push 알람 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <artifactId>jasypt-spring-boot-starter</artifactId>
             <version>3.0.3</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.firebase</groupId>
+            <artifactId>firebase-admin</artifactId>
+            <version>6.8.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/me/soo/helloworld/config/RedisSessionConfig.java
+++ b/src/main/java/me/soo/helloworld/config/RedisSessionConfig.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -14,7 +13,6 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
-@Profile("{prod, local}")
 @Configuration
 @EnableRedisHttpSession
 public class RedisSessionConfig {

--- a/src/main/java/me/soo/helloworld/config/RedisSessionConfig.java
+++ b/src/main/java/me/soo/helloworld/config/RedisSessionConfig.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -15,6 +16,7 @@ import org.springframework.session.data.redis.config.annotation.web.http.EnableR
 
 @Configuration
 @EnableRedisHttpSession
+@Profile({"prod", "local"})
 public class RedisSessionConfig {
 
     @Value("${spring.redis.host}")

--- a/src/main/java/me/soo/helloworld/controller/UserController.java
+++ b/src/main/java/me/soo/helloworld/controller/UserController.java
@@ -25,8 +25,6 @@ public class UserController {
 
     private final LoginService loginService;
 
-    private final PushNotificationService pushNotificationService;
-
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/signup")
     public void userSignUp(@Valid @RequestBody User user) {
@@ -45,20 +43,11 @@ public class UserController {
     @PostMapping("/login")
     public void userLogin(@Valid @RequestBody UserLoginRequest loginRequest) {
         loginService.login(loginRequest);
-
-        if (loginRequest.getToken() != null) {
-            pushNotificationService.registerToken(loginRequest.getUserId(), loginRequest.getToken());
-        }
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @LoginRequired
     @GetMapping("/logout")
-    public void userLogout(@CurrentUser String userId) {
-        if (pushNotificationService.getToken(userId) != null) {
-            pushNotificationService.destroyToken(userId);
-        }
-
+    public void userLogout() {
         loginService.logout();
     }
 

--- a/src/main/java/me/soo/helloworld/enumeration/AlarmTypes.java
+++ b/src/main/java/me/soo/helloworld/enumeration/AlarmTypes.java
@@ -9,11 +9,13 @@ import org.apache.ibatis.type.MappedTypes;
 @RequiredArgsConstructor
 public enum AlarmTypes implements EnumCategory {
 
-    FRIEND_REQUEST_RECEIVED(1),
-    FRIEND_REQUEST_ACCEPTED(2),
-    RECOMMENDATION_LEFT(3);
+    FRIEND_REQUEST_RECEIVED(1, "친구 추가 요청을 받았습니다. 자세한 내용을 보시려면 여기를 클릭해주세요."),
+    FRIEND_REQUEST_ACCEPTED(2, "친구 추가 요청이 수락되었습니다. 자세한 내용을 보시려면 여기를 클릭해주세요."),
+    RECOMMENDATION_LEFT(3, "친구 중 한 명이 추천 글을 남겼습니다. 자세한 내용을 보시려면 여기를 클릭해주세요.");
 
     private final int category;
+
+    private final String message;
 
     @MappedTypes(AlarmTypes.class)
     public static class TypeHandler extends EnumCategoryTypeHandler<AlarmTypes> {

--- a/src/main/java/me/soo/helloworld/exception/FCMUninitializedException.java
+++ b/src/main/java/me/soo/helloworld/exception/FCMUninitializedException.java
@@ -1,0 +1,12 @@
+package me.soo.helloworld.exception;
+
+public class FCMUninitializedException extends RuntimeException {
+
+    public FCMUninitializedException(String message) {
+        super(message);
+    }
+
+    public FCMUninitializedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/me/soo/helloworld/mapper/PushNotificationMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/PushNotificationMapper.java
@@ -1,0 +1,11 @@
+package me.soo.helloworld.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PushNotificationMapper {
+
+    public void upsertToken(String userId, String token);
+
+    public String getToken(String userId);
+}

--- a/src/main/java/me/soo/helloworld/mapper/UserMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/UserMapper.java
@@ -3,6 +3,7 @@ package me.soo.helloworld.mapper;
 import me.soo.helloworld.model.file.FileData;
 import me.soo.helloworld.model.user.User;
 import me.soo.helloworld.model.user.UserFindPasswordRequest;
+import me.soo.helloworld.model.user.UserLoginData;
 import me.soo.helloworld.model.user.UserUpdateRequest;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -16,7 +17,7 @@ public interface UserMapper {
 
     public boolean isUserIdExist(String userId);
 
-    public Optional<User> getUserById(String userId);
+    public Optional<UserLoginData> getUserLoginDataById(String userId);
 
     public FileData getUserProfileImageById(String userId);
 

--- a/src/main/java/me/soo/helloworld/model/notification/PushNotificationRequest.java
+++ b/src/main/java/me/soo/helloworld/model/notification/PushNotificationRequest.java
@@ -1,0 +1,26 @@
+package me.soo.helloworld.model.notification;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class PushNotificationRequest {
+
+    private final String targetId;
+
+    private final String title;
+
+    private final String message;
+
+    public static PushNotificationRequest create(String targetId, String title, String message) {
+
+        return PushNotificationRequest.builder()
+                                    .targetId(targetId)
+                                    .title(title)
+                                    .message(message)
+                                    .build();
+    }
+}

--- a/src/main/java/me/soo/helloworld/model/user/UserLoginData.java
+++ b/src/main/java/me/soo/helloworld/model/user/UserLoginData.java
@@ -1,0 +1,17 @@
+package me.soo.helloworld.model.user;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class UserLoginData {
+
+    private final String userId;
+
+    private final String password;
+
+    private final String token;
+}

--- a/src/main/java/me/soo/helloworld/model/user/UserLoginRequest.java
+++ b/src/main/java/me/soo/helloworld/model/user/UserLoginRequest.java
@@ -1,11 +1,14 @@
 package me.soo.helloworld.model.user;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class UserLoginRequest {
 
@@ -14,4 +17,7 @@ public class UserLoginRequest {
 
     @NotBlank(message = "비밀번호를 입력하세요.")
     private final String password;
+
+    @Nullable
+    private final String token;
 }

--- a/src/main/java/me/soo/helloworld/service/FirebasePushNotificationService.java
+++ b/src/main/java/me/soo/helloworld/service/FirebasePushNotificationService.java
@@ -1,0 +1,97 @@
+package me.soo.helloworld.service;
+
+import com.google.api.core.ApiFuture;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.soo.helloworld.exception.FCMUninitializedException;
+import me.soo.helloworld.model.notification.PushNotificationRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.ExecutionException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FirebasePushNotificationService implements PushNotificationService {
+
+    @Value("${fcm.account.path}")
+    private String accountPath;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @PostConstruct
+    public void init() {
+        try (InputStream serviceAccount = Files.newInputStream(Paths.get(accountPath))) {
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount)).build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                log.info("Firebase Cloud Messaging 서비스를 성공적으로 초기화하였습니다.");
+            }
+        } catch (IOException e) {
+            throw new FCMUninitializedException("Firebase Cloud Messaging 서비스의 초기화에 실패하였습니다.", e);
+        }
+    }
+
+    /*
+        사용자 로그인 시 토큰이 같이 전송되었다면 토큰을 등록합니다.
+     */
+    @Override
+    public void registerToken(String userId, String token) {
+        redisTemplate.opsForValue().set(userId, token);
+    }
+
+    @Override
+    public String getToken(String userId) {
+        return (String) redisTemplate.opsForValue().get(userId);
+    }
+
+    /*
+        사용자 로그아웃 시 토큰도 함께 소멸시킵니다.
+    */
+    @Override
+    public void destroyToken(String userId) {
+        redisTemplate.delete(userId);
+    }
+
+    @Override
+    public void sendPushNotification(PushNotificationRequest pushNotificationRequest) {
+        String token = getToken(pushNotificationRequest.getTargetId());
+
+        if (token == null) {
+            return;
+        }
+
+        Message pushMessage = writePushMessage(pushNotificationRequest, token);
+        ApiFuture<String> response = FirebaseMessaging.getInstance().sendAsync(pushMessage);
+        try {
+            log.info("{} 님에게 푸시 알람 전송을 전송하였습니다. : {}", pushNotificationRequest.getTargetId(), response.get());
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IllegalStateException("푸시알람 전송에 실패하였습니다.", e);
+        }
+    }
+
+    private Message writePushMessage(PushNotificationRequest pushNotificationRequest, String token) {
+        return Message.builder()
+                .setWebpushConfig(WebpushConfig.builder()
+                        .setNotification(WebpushNotification.builder()
+                                .setTitle(pushNotificationRequest.getTitle())
+                                .setBody(pushNotificationRequest.getMessage())
+                                .build())
+                        .build())
+                .setToken(token)
+                .build();
+    }
+}

--- a/src/main/java/me/soo/helloworld/service/FirebasePushNotificationService.java
+++ b/src/main/java/me/soo/helloworld/service/FirebasePushNotificationService.java
@@ -1,7 +1,11 @@
 package me.soo.helloworld.service;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.*;
@@ -18,7 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 
 @Slf4j
 @Service
@@ -67,12 +71,7 @@ public class FirebasePushNotificationService implements PushNotificationService 
         }
 
         Message pushMessage = writePushMessage(pushNotificationRequest, token);
-        ApiFuture<String> response = FirebaseMessaging.getInstance().sendAsync(pushMessage);
-        try {
-            log.info("{} 님에게 푸시 알람 전송을 전송하였습니다. : {}", pushNotificationRequest.getTargetId(), response.get());
-        } catch (InterruptedException | ExecutionException e) {
-            throw new IllegalStateException("푸시알람 전송에 실패하였습니다.", e);
-        }
+        FirebaseMessaging.getInstance().sendAsync(pushMessage);
     }
 
     private Message writePushMessage(PushNotificationRequest pushNotificationRequest, String token) {

--- a/src/main/java/me/soo/helloworld/service/FirebasePushNotificationService.java
+++ b/src/main/java/me/soo/helloworld/service/FirebasePushNotificationService.java
@@ -11,7 +11,6 @@ import me.soo.helloworld.exception.FCMUninitializedException;
 import me.soo.helloworld.mapper.PushNotificationMapper;
 import me.soo.helloworld.model.notification.PushNotificationRequest;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -30,8 +29,6 @@ public class FirebasePushNotificationService implements PushNotificationService 
     private String accountPath;
 
     private final PushNotificationMapper pushNotificationMapper;
-
-    private final RedisTemplate<String, Object> redisTemplate;
 
     @PostConstruct
     public void init() {

--- a/src/main/java/me/soo/helloworld/service/FirebasePushNotificationService.java
+++ b/src/main/java/me/soo/helloworld/service/FirebasePushNotificationService.java
@@ -1,11 +1,6 @@
 package me.soo.helloworld.service;
 
-import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiFutureCallback;
-import com.google.api.core.ApiFutures;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.*;
@@ -22,7 +17,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.concurrent.Executor;
 
 @Slf4j
 @Service

--- a/src/main/java/me/soo/helloworld/service/FirebasePushNotificationService.java
+++ b/src/main/java/me/soo/helloworld/service/FirebasePushNotificationService.java
@@ -8,6 +8,7 @@ import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.soo.helloworld.exception.FCMUninitializedException;
+import me.soo.helloworld.mapper.PushNotificationMapper;
 import me.soo.helloworld.model.notification.PushNotificationRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -27,6 +28,8 @@ public class FirebasePushNotificationService implements PushNotificationService 
 
     @Value("${fcm.account.path}")
     private String accountPath;
+
+    private final PushNotificationMapper pushNotificationMapper;
 
     private final RedisTemplate<String, Object> redisTemplate;
 
@@ -50,20 +53,12 @@ public class FirebasePushNotificationService implements PushNotificationService 
      */
     @Override
     public void registerToken(String userId, String token) {
-        redisTemplate.opsForValue().set(userId, token);
+        pushNotificationMapper.upsertToken(userId, token);
     }
 
     @Override
     public String getToken(String userId) {
-        return (String) redisTemplate.opsForValue().get(userId);
-    }
-
-    /*
-        사용자 로그아웃 시 토큰도 함께 소멸시킵니다.
-    */
-    @Override
-    public void destroyToken(String userId) {
-        redisTemplate.delete(userId);
+        return pushNotificationMapper.getToken(userId);
     }
 
     @Override

--- a/src/main/java/me/soo/helloworld/service/FriendService.java
+++ b/src/main/java/me/soo/helloworld/service/FriendService.java
@@ -8,6 +8,7 @@ import me.soo.helloworld.exception.InvalidRequestException;
 import me.soo.helloworld.mapper.FriendMapper;
 import me.soo.helloworld.model.friend.FriendList;
 import me.soo.helloworld.model.friend.FriendListRequest;
+import me.soo.helloworld.model.notification.PushNotificationRequest;
 import me.soo.helloworld.util.Pagination;
 import me.soo.helloworld.util.validator.TargetUserValidator;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,8 @@ public class FriendService {
 
     private final AlarmService alarmService;
 
+    private final PushNotificationService pushNotificationService;
+
     @Transactional
     public void sendFriendRequest(String userId, String targetId) {
         TargetUserValidator.targetNotSelf(userId, targetId);
@@ -43,6 +46,10 @@ public class FriendService {
 
         friendMapper.sendFriendRequest(userId, targetId);
         alarmService.dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_RECEIVED);
+
+        PushNotificationRequest request = PushNotificationRequest.create(
+                targetId, AlarmTypes.FRIEND_REQUEST_RECEIVED.name(), AlarmTypes.FRIEND_REQUEST_RECEIVED.getMessage());
+        pushNotificationService.sendPushNotification(request);
     }
 
     public FriendStatus getFriendStatus(String userId, String targetId) {
@@ -63,6 +70,10 @@ public class FriendService {
         validateFriendStatus(status, FRIEND_REQUEST_RECEIVED);
         friendMapper.updateFriendRequest(userId, targetId, FRIEND);
         alarmService.dispatchAlarm(targetId, userId, AlarmTypes.FRIEND_REQUEST_ACCEPTED);
+
+        PushNotificationRequest request = PushNotificationRequest.create(
+                targetId, AlarmTypes.FRIEND_REQUEST_ACCEPTED.name(), AlarmTypes.FRIEND_REQUEST_ACCEPTED.getMessage());
+        pushNotificationService.sendPushNotification(request);
     }
 
     public void rejectFriendRequest(String userId, String targetId) {

--- a/src/main/java/me/soo/helloworld/service/PushNotificationService.java
+++ b/src/main/java/me/soo/helloworld/service/PushNotificationService.java
@@ -8,7 +8,5 @@ public interface PushNotificationService {
 
     public String getToken(String userId);
 
-    public void destroyToken(String userId);
-
     public void sendPushNotification(PushNotificationRequest notificationRequest);
 }

--- a/src/main/java/me/soo/helloworld/service/PushNotificationService.java
+++ b/src/main/java/me/soo/helloworld/service/PushNotificationService.java
@@ -1,0 +1,14 @@
+package me.soo.helloworld.service;
+
+import me.soo.helloworld.model.notification.PushNotificationRequest;
+
+public interface PushNotificationService {
+
+    public void registerToken(String userId, String token);
+
+    public String getToken(String userId);
+
+    public void destroyToken(String userId);
+
+    public void sendPushNotification(PushNotificationRequest notificationRequest);
+}

--- a/src/main/java/me/soo/helloworld/service/RecommendationService.java
+++ b/src/main/java/me/soo/helloworld/service/RecommendationService.java
@@ -5,6 +5,7 @@ import me.soo.helloworld.enumeration.AlarmTypes;
 import me.soo.helloworld.exception.DuplicateRequestException;
 import me.soo.helloworld.exception.InvalidRequestException;
 import me.soo.helloworld.mapper.RecommendationMapper;
+import me.soo.helloworld.model.notification.PushNotificationRequest;
 import me.soo.helloworld.model.recommendation.RecommendationForProfile;
 import me.soo.helloworld.model.recommendation.Recommendation;
 import me.soo.helloworld.model.recommendation.Recommendations;
@@ -35,6 +36,8 @@ public class RecommendationService {
 
     private final UserService userService;
 
+    private final PushNotificationService pushNotificationService;
+
     @Transactional
     @CacheEvict(key = "#to", value = USER_PROFILE, cacheManager = REDIS_CACHE_MANAGER)
     public void leaveRecommendation(String from, String to, String content) {
@@ -45,6 +48,10 @@ public class RecommendationService {
 
         recommendationMapper.insertRecommendation(Recommendation.create(from, to, content));
         alarmService.dispatchAlarm(to, from, AlarmTypes.RECOMMENDATION_LEFT);
+
+        PushNotificationRequest request = PushNotificationRequest.create(
+                to, AlarmTypes.RECOMMENDATION_LEFT.name(), AlarmTypes.RECOMMENDATION_LEFT.getMessage());
+        pushNotificationService.sendPushNotification(request);
     }
 
     @CacheEvict(key = "#to", value = USER_PROFILE, cacheManager = REDIS_CACHE_MANAGER)

--- a/src/main/java/me/soo/helloworld/service/SessionLoginService.java
+++ b/src/main/java/me/soo/helloworld/service/SessionLoginService.java
@@ -2,9 +2,10 @@ package me.soo.helloworld.service;
 
 import lombok.RequiredArgsConstructor;
 import me.soo.helloworld.exception.DuplicateLoginRequestException;
-import me.soo.helloworld.model.user.User;
+import me.soo.helloworld.model.user.UserLoginData;
 import me.soo.helloworld.model.user.UserLoginRequest;
 import me.soo.helloworld.util.constant.SessionKeys;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpSession;
@@ -17,16 +18,16 @@ public class SessionLoginService implements LoginService {
 
     private final UserService userService;
 
+    private final PushNotificationService pushNotificationService;
+
     @Override
     public void login(UserLoginRequest loginRequest) {
+        validateDuplicateLogin(getCurrentUserId());
 
-        if (getCurrentUserId() != null) {
-            throw new DuplicateLoginRequestException("이미 로그인 되어 있는 사용자입니다.");
-        }
+        UserLoginData loginData = userService.getUserLoginInfo(loginRequest.getUserId(), loginRequest.getPassword());
+        httpSession.setAttribute(SessionKeys.USER_ID, loginData.getUserId());
 
-        User user = userService.getUser(loginRequest.getUserId(), loginRequest.getPassword());
-
-        httpSession.setAttribute(SessionKeys.USER_ID, user.getUserId());
+        updateTokenIfRequired(loginRequest.getUserId(), loginRequest.getToken(), loginData.getToken());
     }
 
     @Override
@@ -37,6 +38,18 @@ public class SessionLoginService implements LoginService {
     @Override
     public String getCurrentUserId() {
         return (String) httpSession.getAttribute(SessionKeys.USER_ID);
+    }
+
+    private void validateDuplicateLogin(String currentUser) {
+        if (currentUser != null) {
+            throw new DuplicateLoginRequestException("이미 로그인 되어 있는 사용자입니다.");
+        }
+    }
+
+    private void updateTokenIfRequired(String userId, String newToken, String oldToken) {
+        if (!StringUtils.equals(oldToken, newToken)) {
+            pushNotificationService.registerToken(userId, newToken);
+        }
     }
 
 

--- a/src/main/java/me/soo/helloworld/service/SessionLoginService.java
+++ b/src/main/java/me/soo/helloworld/service/SessionLoginService.java
@@ -17,6 +17,7 @@ public class SessionLoginService implements LoginService {
 
     private final UserService userService;
 
+    @Override
     public void login(UserLoginRequest loginRequest) {
 
         if (getCurrentUserId() != null) {
@@ -28,6 +29,7 @@ public class SessionLoginService implements LoginService {
         httpSession.setAttribute(SessionKeys.USER_ID, user.getUserId());
     }
 
+    @Override
     public void logout() {
         httpSession.invalidate();
     }

--- a/src/main/java/me/soo/helloworld/service/UserService.java
+++ b/src/main/java/me/soo/helloworld/service/UserService.java
@@ -41,11 +41,11 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public User getUser(String userId, String password) {
-        User user = userMapper.getUserById(userId)
+    public UserLoginData getUserLoginInfo(String userId, String password) {
+        UserLoginData loginData = userMapper.getUserLoginDataById(userId)
                                 .orElseThrow(() -> new InvalidUserInfoException("해당 사용자는 존재하지 않습니다. 아이디를 다시 확인해 주세요."));
-        isValidPassword(password, user.getPassword());
-        return user;
+        isValidPassword(password, loginData.getPassword());
+        return loginData;
     }
 
     public void userPasswordUpdate(String userid, UserPasswordRequest userPasswordRequest) {

--- a/src/main/resources/mappers/PushNotificationMapper.xml
+++ b/src/main/resources/mappers/PushNotificationMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="me.soo.helloworld.mapper.PushNotificationMapper">
+
+    <insert id="upsertToken" parameterType="String">
+
+        INSERT INTO tokens (userId, token)
+        VALUES (#{userId}, #{token})
+        ON DUPLICATE KEY UPDATE token = #{token}
+    </insert>
+
+    <select id="getToken" parameterType="String" resultType="String">
+
+        SELECT token FROM tokens
+        WHERE userId = #{userId}
+    </select>
+</mapper>

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -22,8 +22,8 @@
             <arg column="token" javaType="String"/>
         </constructor>
         <result property="userId" column="userId"/>
-        <result property="userId" column="password"/>
-        <result property="userId" column="token"/>
+        <result property="password" column="password"/>
+        <result property="token" column="token"/>
     </resultMap>
 
     <select id="getUserLoginDataById"

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -15,12 +15,27 @@
         SELECT EXISTS (SELECT userId FROM users WHERE userId = #{userId})
     </select>
 
-    <select id="getUserById"
-            parameterType="String" resultType="me.soo.helloworld.model.user.User">
+    <resultMap id="getUserLoginData" type="me.soo.helloworld.model.user.UserLoginData">
+        <constructor>
+            <arg column="userId" javaType="String"/>
+            <arg column="password" javaType="String"/>
+            <arg column="token" javaType="String"/>
+        </constructor>
+        <result property="userId" column="userId"/>
+        <result property="userId" column="password"/>
+        <result property="userId" column="token"/>
+    </resultMap>
 
-        SELECT userId, password, email, gender, birthDay, originCountry, livingCountry, livingTown, aboutMe,
-               profileImageName, profileImagePath
-        FROM users WHERE userId = #{userId} AND isDeactivated = 'N';
+    <select id="getUserLoginDataById"
+            parameterType="String" resultMap="getUserLoginData">
+
+        SELECT
+            u.userId AS userId,
+            u.password AS password,
+            t.token AS token
+        FROM users AS u
+            LEFT OUTER JOIN tokens AS t on u.userId = t.userId
+        WHERE u.userId = #{userId} AND isDeactivated = 'N';
     </select>
 
     <select id="getUserProfileImageById"

--- a/src/main/resources/sql/tokens.sql
+++ b/src/main/resources/sql/tokens.sql
@@ -1,0 +1,9 @@
+create table tokens
+(
+    id     bigint auto_increment
+        primary key,
+    userId varchar(20)  not null,
+    token  varchar(255) null,
+    constraint userId
+        unique (userId)
+);

--- a/src/test/java/me/soo/helloworld/integration/ITSearchProfiles.java
+++ b/src/test/java/me/soo/helloworld/integration/ITSearchProfiles.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
-public class ITSearchProfilesTest {
+public class ITSearchProfiles {
 
     @Autowired
     UserService userService;

--- a/src/test/java/me/soo/helloworld/integration/ITUserController.java
+++ b/src/test/java/me/soo/helloworld/integration/ITUserController.java
@@ -106,9 +106,12 @@ class ITUserController {
     public void userLoginSuccess() throws Exception {
         testUserSignUp(testUser);
 
-        UserLoginRequest testLoginRequest = new UserLoginRequest(testUser.getUserId(), testUser.getPassword());
+        UserLoginRequest loginRequest = UserLoginRequest.builder()
+                .userId(testUser.getUserId())
+                .password(testUser.getPassword())
+                .build();
 
-        String loginContent = objectMapper.writeValueAsString(testLoginRequest);
+        String loginContent = objectMapper.writeValueAsString(loginRequest);
 
         mockMvc.perform(post("/users/login")
                 .content(loginContent)
@@ -125,8 +128,12 @@ class ITUserController {
 
         httpSession.setAttribute("userId", testUser.getUserId());
 
-        UserLoginRequest testUserLogin = new UserLoginRequest(testUser.getUserId(), testUser.getPassword());
-        String loginContent = objectMapper.writeValueAsString(testUserLogin);
+        UserLoginRequest loginRequest = UserLoginRequest.builder()
+                .userId(testUser.getUserId())
+                .password(testUser.getPassword())
+                .build();
+
+        String loginContent = objectMapper.writeValueAsString(loginRequest);
 
         mockMvc.perform(post("/users/login")
                 .content(loginContent)
@@ -141,8 +148,12 @@ class ITUserController {
     public void userLoginFailNoSuchUser() throws Exception {
         testUserSignUp(testUser);
 
-        UserLoginRequest testUserLogin = new UserLoginRequest("WrongID!@34", "WrongPw!@34");
-        String loginContent = objectMapper.writeValueAsString(testUserLogin);
+        UserLoginRequest loginRequest = UserLoginRequest.builder()
+                .userId("WrongID!@34")
+                .password("WrongPw!@34")
+                .build();
+
+        String loginContent = objectMapper.writeValueAsString(loginRequest);
 
         mockMvc.perform(post("/users/login")
                 .content(loginContent)

--- a/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/FriendServiceTest.java
@@ -37,6 +37,9 @@ public class FriendServiceTest {
     @Mock
     AlarmService alarmService;
 
+    @Mock
+    PushNotificationService pushNotificationService;
+
     /*
         친구 요청을 보낼 때 발생할 수 있는 예외들
 

--- a/src/test/java/me/soo/helloworld/service/RecommendationServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/RecommendationServiceTest.java
@@ -50,6 +50,9 @@ public class RecommendationServiceTest {
     @Mock
     UserService userService;
 
+    @Mock
+    PushNotificationService pushNotificationService;
+
     String recommendationContent;
 
     String modifiedRecommendationContent;

--- a/src/test/java/me/soo/helloworld/service/login/LoginServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/login/LoginServiceTest.java
@@ -59,8 +59,11 @@ public class LoginServiceTest {
     @Test
     @DisplayName("DB에 등록된 회원정보와 일치하는 로그인 요청이 오면 로그인에 성공합니다.")
     public void successLoginRequestWithCorrectLoginRequest() {
+        UserLoginRequest loginRequest = UserLoginRequest.builder()
+                .userId(testUser.getUserId())
+                .password(testUser.getPassword())
+                .build();
 
-        UserLoginRequest loginRequest = new UserLoginRequest(testUser.getUserId(), testUser.getPassword());
         when(userService.getUser(loginRequest.getUserId(), loginRequest.getPassword())).thenReturn(testUser);
 
         loginService.login(loginRequest);
@@ -71,7 +74,10 @@ public class LoginServiceTest {
     @Test
     @DisplayName("이미 로그인 된 회원에게서 또 다시 로그인 요청이 오면 DuplicateLoginRequestException이 발생합니다.")
     public void failLoginRequestWithWrongLoginRequest() {
-        UserLoginRequest loginRequest = new UserLoginRequest(testUser.getUserId(), testUser.getPassword());
+        UserLoginRequest loginRequest = UserLoginRequest.builder()
+                .userId(testUser.getUserId())
+                .password(testUser.getPassword())
+                .build();
 
         httpSession.setAttribute(SessionKeys.USER_ID, loginRequest.getUserId());
 

--- a/src/test/java/me/soo/helloworld/service/login/LoginServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/login/LoginServiceTest.java
@@ -1,6 +1,7 @@
 package me.soo.helloworld.service.login;
 
 import me.soo.helloworld.exception.DuplicateLoginRequestException;
+import me.soo.helloworld.model.user.UserLoginData;
 import me.soo.helloworld.model.user.UserLoginRequest;
 import me.soo.helloworld.model.user.User;
 import me.soo.helloworld.service.SessionLoginService;
@@ -31,6 +32,8 @@ public class LoginServiceTest {
 
     User testUser;
 
+    UserLoginData testUserLoginData;
+
     @InjectMocks
     SessionLoginService loginService;
 
@@ -54,6 +57,10 @@ public class LoginServiceTest {
                 .aboutMe("Hello, I'd love to make great friends here")
                 .build();
 
+        testUserLoginData = UserLoginData.builder()
+                .userId(testUser.getUserId())
+                .password(testUser.getPassword())
+                .build();
     }
 
     @Test
@@ -64,7 +71,7 @@ public class LoginServiceTest {
                 .password(testUser.getPassword())
                 .build();
 
-        when(userService.getUser(loginRequest.getUserId(), loginRequest.getPassword())).thenReturn(testUser);
+        when(userService.getUserLoginInfo(loginRequest.getUserId(), loginRequest.getPassword())).thenReturn(testUserLoginData);
 
         loginService.login(loginRequest);
 

--- a/src/test/java/me/soo/helloworld/service/user/UserServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/user/UserServiceTest.java
@@ -5,6 +5,7 @@ import me.soo.helloworld.mapper.UserMapper;
 import me.soo.helloworld.model.email.EmailBase;
 import me.soo.helloworld.model.email.FindPasswordEmail;
 import me.soo.helloworld.model.user.UserFindPasswordRequest;
+import me.soo.helloworld.model.user.UserLoginData;
 import me.soo.helloworld.model.user.UserLoginRequest;
 import me.soo.helloworld.model.user.User;
 import me.soo.helloworld.service.EmailService;
@@ -35,8 +36,9 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
 
-    @Mock
     User testUser;
+
+    UserLoginData testUserLoginData;
 
     @InjectMocks
     UserService userService;
@@ -62,6 +64,11 @@ class UserServiceTest {
                 .livingCountry(UNITED_KINGDOM)
                 .livingTown(NEWCASTLE)
                 .aboutMe("Hello, I'd love to make great friends here")
+                .build();
+
+        testUserLoginData = UserLoginData.builder()
+                .userId(testUser.getUserId())
+                .password(testUser.getPassword())
                 .build();
     }
 
@@ -93,12 +100,12 @@ class UserServiceTest {
                 .password(testUser.getPassword())
                 .build();
 
-        when(userMapper.getUserById(loginRequest.getUserId())).thenReturn(Optional.ofNullable(testUser));
+        when(userMapper.getUserLoginDataById(loginRequest.getUserId())).thenReturn(Optional.ofNullable(testUserLoginData));
         when(passwordEncoder.isMatch(loginRequest.getPassword(), testUser.getPassword())).thenReturn(true);
 
-        userService.getUser(loginRequest.getUserId(), loginRequest.getPassword());
+        userService.getUserLoginInfo(loginRequest.getUserId(), loginRequest.getPassword());
 
-        verify(userMapper, times(1)).getUserById(loginRequest.getUserId());
+        verify(userMapper, times(1)).getUserLoginDataById(loginRequest.getUserId());
         verify(passwordEncoder, times(1)).isMatch(loginRequest.getPassword(), testUser.getPassword());
     }
 
@@ -110,13 +117,13 @@ class UserServiceTest {
                 .password(testUser.getPassword())
                 .build();
 
-        when(userMapper.getUserById(loginRequest.getUserId())).thenReturn(Optional.empty());
+        when(userMapper.getUserLoginDataById(loginRequest.getUserId())).thenReturn(Optional.empty());
 
         assertThrows(InvalidUserInfoException.class, () -> {
-           userService.getUser(loginRequest.getUserId(), loginRequest.getPassword());
+           userService.getUserLoginInfo(loginRequest.getUserId(), loginRequest.getPassword());
         });
 
-        verify(userMapper, times(1)).getUserById(loginRequest.getUserId());
+        verify(userMapper, times(1)).getUserLoginDataById(loginRequest.getUserId());
     }
 
     @Test
@@ -127,14 +134,14 @@ class UserServiceTest {
                 .password("Typo is everywhere ~.")
                 .build();
 
-        when(userMapper.getUserById(loginRequest.getUserId())).thenReturn(Optional.ofNullable(testUser));
+        when(userMapper.getUserLoginDataById(loginRequest.getUserId())).thenReturn(Optional.ofNullable(testUserLoginData));
         when(passwordEncoder.isMatch(loginRequest.getPassword(), testUser.getPassword())).thenReturn(false);
 
         assertThrows(InvalidUserInfoException.class, () -> {
-            userService.getUser(loginRequest.getUserId(), loginRequest.getPassword());
+            userService.getUserLoginInfo(loginRequest.getUserId(), loginRequest.getPassword());
         });
 
-        verify(userMapper, times(1)).getUserById(loginRequest.getUserId());
+        verify(userMapper, times(1)).getUserLoginDataById(loginRequest.getUserId());
         verify(passwordEncoder, times(1)).isMatch(loginRequest.getPassword(), testUser.getPassword());
     }
 

--- a/src/test/java/me/soo/helloworld/service/user/UserServiceTest.java
+++ b/src/test/java/me/soo/helloworld/service/user/UserServiceTest.java
@@ -88,7 +88,11 @@ class UserServiceTest {
     @Test
     @DisplayName("유저 정보를 얻기 위해 요청 받은 아이디와 비밀번호가 DB에 저장되어 있는 사용자의 아이디와 비밀번호에 일치하는 경우 사용자를 리턴하는데 성공합니다.")
     public void getUserWithCorrectIdAndPasswordSuccess() {
-        UserLoginRequest loginRequest = new UserLoginRequest(testUser.getUserId(), testUser.getPassword());
+        UserLoginRequest loginRequest = UserLoginRequest.builder()
+                .userId(testUser.getUserId())
+                .password(testUser.getPassword())
+                .build();
+
         when(userMapper.getUserById(loginRequest.getUserId())).thenReturn(Optional.ofNullable(testUser));
         when(passwordEncoder.isMatch(loginRequest.getPassword(), testUser.getPassword())).thenReturn(true);
 
@@ -101,7 +105,11 @@ class UserServiceTest {
     @Test
     @DisplayName("유저 정보를 얻기 위해 요청 받은 아이디가 DB에 존재하지 않는 경우 InvalidUserInfoException 이 발생하며 테스트에 실패합니다.")
     public void getUserWithWrongIdFail() {
-        UserLoginRequest loginRequest = new UserLoginRequest("I'm a wrong user", testUser.getPassword());
+        UserLoginRequest loginRequest = UserLoginRequest.builder()
+                .userId("I'm a wrong user.")
+                .password(testUser.getPassword())
+                .build();
+
         when(userMapper.getUserById(loginRequest.getUserId())).thenReturn(Optional.empty());
 
         assertThrows(InvalidUserInfoException.class, () -> {
@@ -114,7 +122,11 @@ class UserServiceTest {
     @Test
     @DisplayName("유저 정보를 얻기 위해 요청 받은 비밀번호가 일치하지 않는 경우 InvalidUserInfoException 이 발생하며 테스트에 실패합니다.")
     public void getUserWithWrongPasswordFail() {
-        UserLoginRequest loginRequest = new UserLoginRequest(testUser.getUserId(), "Typo is everywhere~");
+        UserLoginRequest loginRequest = UserLoginRequest.builder()
+                .userId(testUser.getUserId())
+                .password("Typo is everywhere ~.")
+                .build();
+
         when(userMapper.getUserById(loginRequest.getUserId())).thenReturn(Optional.ofNullable(testUser));
         when(passwordEncoder.isMatch(loginRequest.getPassword(), testUser.getPassword())).thenReturn(false);
 


### PR DESCRIPTION
## 📖 Model 관련

### 📑  PushNotificationRequest

- 푸시 알람과 관련한 요청에 사용할 인스턴스를 만들 클래스 생성

- 푸시 알람을 보내는 targetId, 제목, 그리고 메시지를 멤버 변수로 가짐

### 📑 UserLoginRequest

- 토큰도 함께 서버로 전달될 수 있도록 `token` 변수 추가

- Builder를 추가 해 token 없이도 테스트 시 인스턴스를 생성할 수 있게 변경

### 📑 UserLoginData

- 사용자가 로그인 요청을 위해 보낸 ID와 일치하는 로그인 정보를 DB에서 받아올 객체를 생성하기 위한 클래스 생성

## 📖 Enum 관련

### 📑 AlarmTypes

- 푸시 알람에 사용할 수 있는 message 값 또한 멤버 변수로 추가

## 📖 Service 계층 관련

### 📑 PushNotificationService, FirebasePushNotificationService

- PushNotification은 FCM 외에도 다른 솔루션을 사용할 수 있으므로, 기본 뼈대인 인터페이스를 두고 이를 구현하도록 설계

- FCM 서비스를 활성화하는 init 메소드 추가

- 사용자가 로그인 시 보낸 token을 Redis 저장소에 등록하는 `registerToken` 메소드 추가

- 저장한 토큰을 얻어오는 `getToken` 메소드 추가

- 메시지를 만들고 푸시 알람을 만들 `sendPushNotification` 메소드 추가

### 📑 FriendService, RecommendationService

 - 친구 추가 요청, 친구 추가 요청 승낙, 추천글 등록 시 푸시 알람을 함께 보낼 수 있도록 코드 추가

### 📑 SessionLoginService

- 중복 로그인 검사 코드를 별도의 메소드로 추출

- 로그인 시 DB에서 유저 정보를 모두 받아오는 것이 아니라 필요한 정보만 받아오도록 변경 (id, password, 조인 후 token)

- 받아온 토큰은 로그인 시 함께 들어온 토큰과 일치여부 검사 후 일치하지 않은 경우만 DB에 업데이트 반영

### 📑 UserService

- `getUser -> getUserLoginInfo`로 메소드 이름 변경

- 로그인에 사용할 사용자 정보를 전체 사용자 정보가 아닌 필요한 정보만
  리턴하도록 변경

## 📖 Mapper 계층 관련

### 📑 UserMapper, UserMapper.xml

- getUserLoginInfo로 메소드를 변경한 부분 업데이트 반영

- 조인 후 사용자에게 저장된 토큰을 받아올 수 있도록 쿼리 변경

### 📑 PushNotificationMapper, PushNotificationMapper.xml

- DB에 토큰을 저장/업데이트하고 받아올 `upsertToken`, `getToken` 메소드 추가

- 위의 내용을 처리할 쿼리 추가 (특히, upsertToken의 경우 INSERT INTO ~  ON DUPLICATE KEY UPDATE 쿼리 사용)

## 📖 테스트 관련

- 위의 변경 사항을 테스트 코드에 반영

- 테스트 코드의 동작 확인

