### PR TITLE
[#44] 사용자의 채팅함 목록 불러오기 기능 추가

### DIFF
--- a/src/main/java/me/soo/helloworld/controller/ChatController.java
+++ b/src/main/java/me/soo/helloworld/controller/ChatController.java
@@ -3,17 +3,23 @@ package me.soo.helloworld.controller;
 import lombok.RequiredArgsConstructor;
 import me.soo.helloworld.annotation.CurrentUser;
 import me.soo.helloworld.annotation.LoginRequired;
+import me.soo.helloworld.model.chat.ChatBox;
 import me.soo.helloworld.model.chat.ChatSendRequest;
 import me.soo.helloworld.service.ChatService;
+import me.soo.helloworld.util.Pagination;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class ChatController {
+
+    @Value("${max.page.size:30}")
+    private int pageSize;
 
     private final ChatService chatService;
 
@@ -21,5 +27,12 @@ public class ChatController {
     @MessageMapping("/chat")
     public void sendChat(@CurrentUser String sender, @Payload ChatSendRequest chatRequest) {
         chatService.sendChat(sender, chatRequest);
+    }
+
+    @LoginRequired
+    @GetMapping("/chat-boxes")
+    public List<ChatBox> getChatBoxes(@CurrentUser String userId,
+                                      @RequestParam(required = false) Integer cursor) {
+        return chatService.getChatBoxes(userId, Pagination.create(cursor, pageSize));
     }
 }

--- a/src/main/java/me/soo/helloworld/mapper/ChatMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/ChatMapper.java
@@ -1,7 +1,10 @@
 package me.soo.helloworld.mapper;
 
+import me.soo.helloworld.model.chat.ChatBox;
 import me.soo.helloworld.model.chat.ChatWrite;
+import me.soo.helloworld.util.Pagination;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -15,4 +18,7 @@ public interface ChatMapper {
     public void insertChatBox(String sender, String recipient);
 
     public int getChatBoxId(String sender, String recipient);
+
+    public List<ChatBox> getChatBoxes(@Param("userId") String userId,
+                                      @Param("pagination") Pagination pagination);
 }

--- a/src/main/java/me/soo/helloworld/model/chat/ChatBox.java
+++ b/src/main/java/me/soo/helloworld/model/chat/ChatBox.java
@@ -1,0 +1,21 @@
+package me.soo.helloworld.model.chat;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatBox {
+
+    private final int id;
+
+    private final int chatBoxId;
+
+    private final String partner;
+
+    private final String content;
+
+    private final LocalDateTime sentAt;
+}

--- a/src/main/java/me/soo/helloworld/service/ChatService.java
+++ b/src/main/java/me/soo/helloworld/service/ChatService.java
@@ -3,11 +3,14 @@ package me.soo.helloworld.service;
 import lombok.RequiredArgsConstructor;
 import me.soo.helloworld.mapper.ChatMapper;
 import me.soo.helloworld.model.chat.*;
+import me.soo.helloworld.util.Pagination;
 import me.soo.helloworld.util.validator.TargetUserValidator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +41,11 @@ public class ChatService {
         kafkaProducerService.deliverChatsToKafka(kafkaTopic, chat);
         messagingTemplate.convertAndSendToUser(chat.getRecipient(), "/queue/messages",
                 new ChatNotification(chat.getSender(), chat.getContent()));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatBox> getChatBoxes(String userId, Pagination pagination) {
+        return chatMapper.getChatBoxes(userId, pagination);
     }
 
     private int fetchChatBoxId(String sender, String recipient) {

--- a/src/main/resources/mappers/ChatMapper.xml
+++ b/src/main/resources/mappers/ChatMapper.xml
@@ -34,4 +34,22 @@
 	    AND userTwo in (#{sender}, #{recipient})
     </select>
 
+    <select id="getChatBoxes" parameterType="map" resultType="me.soo.helloworld.model.chat.ChatBox">
+
+        SELECT
+            c1.id AS id,
+            c1.chatBoxId AS chatBoxId,
+            IF(c1.recipient = #{userId}, c1.sender, c1.recipient) AS partner,
+            c1.content AS content,
+            c1.sentAt AS sentAt
+        FROM chats AS c1
+            LEFT OUTER JOIN chats AS c2 on c1.chatBoxId = c2.chatboxId AND c1.id <![CDATA[<]]> c2.id
+        WHERE c2.id IS NULL
+            <if test="pagination.cursor != null">
+            AND c1.id <![CDATA[<]]> #{pagination.cursor}
+            </if>
+            AND #{userId} IN (c1.recipient, c1.sender)
+        ORDER BY id DESC
+        LIMIT #{pagination.pageSize}
+    </select>
 </mapper>


### PR DESCRIPTION
## 📖 Controller 계층 관련

### 📑  ChatController

- cursor를 RequestParam으로 받아 `커서 형식의 채팅함 목록 불러오기` 기능의 요청을 매핑할 엔드포인트를 담당하는 `getChatBoxes` 메소드 추가

## 📖 Service 계층 관련

### 📑 ChatService

- 채팅함 목록 불러오기 요청을 전달 받아 다시 Mapper 계층으로 전달해 줄 비즈니스 로직 `getChatBoxes` 추가

## 📖 Mapper 계층 관련

### 📑 ChatMapper

- DB에서 커서 방식으로 채팅함 목록을 불러올 getChatBoxes 메소드 추가

### 📑 ChatMapper.xml

- 위의 메소드의 동작을 처리할 쿼리 작성

## 📖 Model 관련

- DB에서 가져온 채팅함 관련 데이터를 담을 인스턴스를 생성할 ChatBox 클래스 작성

## 📖 테스트 관련

- 포스트맨을 활용해 전반적인 테스트