### PR TITLE
[#45] 채팅 메시지 읽어오기 기능 구현

### DIFF
--- a/src/main/java/me/soo/helloworld/controller/ChatController.java
+++ b/src/main/java/me/soo/helloworld/controller/ChatController.java
@@ -3,6 +3,7 @@ package me.soo.helloworld.controller;
 import lombok.RequiredArgsConstructor;
 import me.soo.helloworld.annotation.CurrentUser;
 import me.soo.helloworld.annotation.LoginRequired;
+import me.soo.helloworld.model.chat.Chat;
 import me.soo.helloworld.model.chat.ChatBox;
 import me.soo.helloworld.model.chat.ChatSendRequest;
 import me.soo.helloworld.service.ChatService;
@@ -34,5 +35,13 @@ public class ChatController {
     public List<ChatBox> getChatBoxes(@CurrentUser String userId,
                                       @RequestParam(required = false) Integer cursor) {
         return chatService.getChatBoxes(userId, Pagination.create(cursor, pageSize));
+    }
+
+    @LoginRequired
+    @GetMapping("/{chat-box-id}/chats")
+    public List<Chat> getChats(@PathVariable("chat-box-id") Integer chatBoxId,
+                               @CurrentUser String userId,
+                               @RequestParam(required = false) Integer cursor) {
+        return chatService.getChats(chatBoxId, userId, Pagination.create(cursor, pageSize));
     }
 }

--- a/src/main/java/me/soo/helloworld/mapper/ChatMapper.java
+++ b/src/main/java/me/soo/helloworld/mapper/ChatMapper.java
@@ -1,5 +1,6 @@
 package me.soo.helloworld.mapper;
 
+import me.soo.helloworld.model.chat.Chat;
 import me.soo.helloworld.model.chat.ChatBox;
 import me.soo.helloworld.model.chat.ChatWrite;
 import me.soo.helloworld.util.Pagination;
@@ -21,4 +22,10 @@ public interface ChatMapper {
 
     public List<ChatBox> getChatBoxes(@Param("userId") String userId,
                                       @Param("pagination") Pagination pagination);
+
+    public List<Chat> getChats(@Param("chatBoxId") int chatBoxId,
+                               @Param("userId") String userId,
+                               @Param("pagination") Pagination pagination);
+
+    public void updateToRead(List<Integer> unReadChatIds);
 }

--- a/src/main/java/me/soo/helloworld/model/chat/Chat.java
+++ b/src/main/java/me/soo/helloworld/model/chat/Chat.java
@@ -1,0 +1,23 @@
+package me.soo.helloworld.model.chat;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class Chat {
+
+    private final int id;
+
+    private final String recipient;
+
+    private final String sender;
+
+    private final String content;
+
+    private final String hasRead;
+
+    private final LocalDateTime sentAt;
+}

--- a/src/main/resources/mappers/ChatMapper.xml
+++ b/src/main/resources/mappers/ChatMapper.xml
@@ -57,11 +57,12 @@
 
         SELECT id, recipient, sender, content, hasRead, sentAt
         FROM chats
-        WHERE chatBoxId = #{chatBoxId}
+        WHERE
         <if test="pagination.cursor != null">
-            AND id <![CDATA[<]]> #{pagination.cursor}
+            id <![CDATA[<]]> #{pagination.cursor} AND
         </if>
-            AND #{userId} IN (sender, recipient)
+            chatBoxId = #{chatBoxId} AND
+            #{userId} IN (sender, recipient)
         ORDER BY id DESC
         LIMIT #{pagination.pageSize}
     </select>

--- a/src/main/resources/mappers/ChatMapper.xml
+++ b/src/main/resources/mappers/ChatMapper.xml
@@ -52,4 +52,24 @@
         ORDER BY id DESC
         LIMIT #{pagination.pageSize}
     </select>
+
+    <select id="getChats" parameterType="map" resultType="me.soo.helloworld.model.chat.Chat">
+
+        SELECT id, recipient, sender, content, hasRead, sentAt
+        FROM chats
+        WHERE chatBoxId = #{chatBoxId}
+        <if test="pagination.cursor != null">
+            AND id <![CDATA[<]]> #{pagination.cursor}
+        </if>
+            AND #{userId} IN (sender, recipient)
+        ORDER BY id DESC
+        LIMIT #{pagination.pageSize}
+    </select>
+
+    <update id="updateToRead" parameterType="int">
+
+        UPDATE chats SET hasRead = 'Y'
+        WHERE id
+        IN (<foreach collection="unReadChatIds" item="id" separator=","> #{id} </foreach>)
+    </update>
 </mapper>


### PR DESCRIPTION
## 📖 Model 관련

### 📑  Chat

- DB에서 읽어온 채팅관련 데이터를 담을 인스턴스를 생성할 클래스 추가

Controller 계층 관련

### 📑 ChatController

- 채팅 메시지를 읽어오는 요청에 대해 채팅함 Id, 현재 사용자 Id, 그리고 Cursor를 전달받으면 이를 매핑해줄`getChats` 메소드 추가

## 📖 Service 계층 관련

### 📑 ChatService

- 전달 받은 파라미터를 통해 커서 방식으로 DB에서 채팅을 읽어 오는 로직을 Mapper 계층으로 전달할 getChats 메소드 추가

- 받아온 채팅 메시지 중 읽지 않은 메시지가 있다면 읽음으로 변경하기 위한 로직을 담은 `markUnreadAsRead` 메소드 추가

## 📖 Mapper 계층 관련

### 📑 ChatMapper

- DB에서 커서방식으로 여러 개의 채팅 메시지를 한번에 읽어 올 `getChats` 메소드 추가

- 읽지 않을 메시지의 hasRead 값을 'Y'로 업데이트 할 `updateToRead` 메소드 추가

### 📑 ChatMapper.xml

- 위의 로직을 처리할 쿼리 추가