### PR TITLE
[#50] 성능 테스트 후 전체 사용자 프로필 조회 쿼리 개선하기

### DIFF
--- a/src/main/java/me/soo/helloworld/model/user/User.kt
+++ b/src/main/java/me/soo/helloworld/model/user/User.kt
@@ -46,18 +46,6 @@ data class User @JvmOverloads constructor(
     val profileImagePath: String? = null
 ) {
 
-    companion object {
-        fun verifyPassword(reqPassword: String, userPassword: String, passwordEncoder: PasswordEncoder) {
-            if (!passwordEncoder.isMatch(reqPassword, userPassword))
-                throw InvalidUserInfoException("입력하신 비밀번호가 일치하지 않습니다. 다시 한 번 확인해주세요.")
-        }
-
-        fun verifyEmail(isEmailValid: Boolean) {
-            if (!isEmailValid)
-                throw InvalidUserInfoException("해당 사용자가 존재하지 않거나 이메일이 일치하지 않습니다. 입력하신 정보를 다시 확인해 주세요.")
-        }
-    }
-
     fun createUserWithEncodedPassword(encodedPassword: String) =
         User(
             userId = userId,

--- a/src/main/java/me/soo/helloworld/model/user/User.kt
+++ b/src/main/java/me/soo/helloworld/model/user/User.kt
@@ -1,7 +1,5 @@
 package me.soo.helloworld.model.user
 
-import me.soo.helloworld.exception.InvalidUserInfoException
-import me.soo.helloworld.util.encoder.PasswordEncoder
 import java.util.Date
 import javax.validation.constraints.Pattern
 

--- a/src/main/resources/mappers/ProfileMapper.xml
+++ b/src/main/resources/mappers/ProfileMapper.xml
@@ -71,22 +71,29 @@
         <result property="aboutMe" column="aboutMe"/>
         <result property="profileImageName" column="profileImageName"/>
         <result property="profileImagePath" column="profileImagePath"/>
-        <association property="recommendationNums" column="userId"
-                     javaType="_int" select="getTotalRecommendationsNums"/>
+        <result property="recommendationNums" column="recommendationNums" />
     </resultMap>
 
     <select id="getUserProfiles" parameterType="map"
             resultMap="getUserProfilesMap">
-        SELECT id, userId, aboutMe,
-               profileImageName, profileImagePath
-        FROM users
+
+        SELECT
+            u.id AS id,
+            u.userId AS userId,
+            u.aboutMe AS aboutMe,
+            u.profileImageName AS profileImageName,
+            u.profileImagePath AS profileImagePath,
+            COUNT(r.recomTo) AS recommendationNums
+        FROM users AS u
+            LEFT OUTER JOIN recommendations AS r ON u.userId = r.recomTo
         WHERE
         <if test="pagination.cursor != null">
-            id <![CDATA[<]]> #{pagination.cursor} AND
+            u.id <![CDATA[<]]> #{pagination.cursor} AND
         </if>
-        isDeactivated = 'N'
-        AND userId NOT IN (SELECT blockedBy FROM block WHERE blockId = #{userId})
-        ORDER BY id DESC
+        u.isDeactivated = 'N' AND
+        u.userId NOT IN (SELECT blockedBy FROM block WHERE blockId = #{userId})
+        GROUP BY u.id
+        ORDER BY u.id DESC
         LIMIT #{pagination.pageSize}
     </select>
     


### PR DESCRIPTION
### 📑 전체 사용자 프로필 조회 기능 사용 시 발생하는 N + 1 문제 개선

- 성능테스트 중 APM 모니터링에 심각한 성능저하가 발생하는 것을 목격

- 원인을 분석해보니 전체 사용자 프로필 조회 기능 수행 시 N+1 문제가 발생하고 있었음
: 내부에서 Association과 연계하여 Select를 통해 다시 해당 사용자에 대해 추천글 개수를 가져오다보니 각 유저마다 SELECT문이 추가로 하나씩 더 수행되는 문제가 발생

- Association 키워드를 없애 SELECT로 다시 가져오는 쿼리 대신, 조인 연산을 활용하여 연산 결과만을 가져오게 함으로써 N+1문제 해결
